### PR TITLE
Bug fix: Issue #21

### DIFF
--- a/src/images/images_peeled.f90
+++ b/src/images/images_peeled.f90
@@ -130,7 +130,7 @@ contains
           tmax = - d_min(ig) + d
        end if
 
-       if(d < d_min(ig) .or. d > d_max(ig)) return
+       if(d < d_min(ig) .or. d > d_max(ig)) cycle
 
        if(inside_observer(ig)) then
 


### PR DESCRIPTION
In src/images/images_peeled.f90:peeloff_photon changed the program control 
statement for out-of-distance-range photons from 'return' to 'cycle'.  With
the 'return' statement, a given photon was not considered for subsequent
peeled images if it was out-of-distance-range for any one image because the
subroutine was returned.  The change to 'cycle' ends consideration of the
photon for the present peeled image, but cycles the DO loop to the next
peeled image.
10/02/12, TPEB
