### PR TITLE
Tentative fix for issue #89.

### DIFF
--- a/configure
+++ b/configure
@@ -1824,7 +1824,7 @@ else
 fi
 
 # gfortran sometimes includes version number, so check whether this is the case
-hdf_compiler_short=`echo $hdf_compiler | cut -c1-8`
+hdf_compiler_short=`echo $hdf_compiler | sed s/'.*gfortran.*'/gfortran/`
 if test "$hdf_compiler_short" == gfortran
 then
   hdf_compiler=gfortran
@@ -1949,7 +1949,7 @@ else
 fi
 
 # gfortran sometimes includes version number, so check whether this is the case
-mpi_compiler_short=`echo $mpi_compiler | cut -c1-8`
+mpi_compiler_short=`echo $mpi_compiler | sed s/'.*gfortran.*'/gfortran/`
 if test "$mpi_compiler_short" == gfortran
 then
   mpi_compiler=gfortran

--- a/configure.ac
+++ b/configure.ac
@@ -89,8 +89,9 @@ else
   fi
 fi
 
-# gfortran sometimes includes version number, so check whether this is the case
-hdf_compiler_short=`echo $hdf_compiler | cut -c1-8`
+# gfortran sometimes includes version number and/or platform info
+# (e.g., x86_64-pc-linux-gnu-gfortran-4.8.2), so check whether this is the case
+hdf_compiler_short=`echo $hdf_compiler | sed s/'.*gfortran.*'/gfortran/`
 if test "$hdf_compiler_short" == gfortran
 then
   hdf_compiler=gfortran
@@ -155,8 +156,9 @@ else
   AC_ERROR(["h5pfc or mpif90 need to be present"])
 fi
 
-# gfortran sometimes includes version number, so check whether this is the case
-mpi_compiler_short=`echo $mpi_compiler | cut -c1-8`
+# gfortran sometimes includes version number and/or platform info
+# (e.g., x86_64-pc-linux-gnu-gfortran-4.8.2), so check whether this is the case
+mpi_compiler_short=`echo $mpi_compiler | sed s/'.*gfortran.*'/gfortran/`
 if test "$mpi_compiler_short" == gfortran
 then
   mpi_compiler=gfortran


### PR DESCRIPTION
See #89.

Try to be more generic in the configure script when checking for funky gfortran compiler names.

@astrofrog Can we assume `sed` is available on all supported platforms? Could you check on OSX please? :)

Also, not sure it is necessary to change the `configure` script, as it is generated from the .ac. But since it is included in the repo I thought I would change it as well.
