### PR TITLE
Add out of grid warnings for Voronoi grid and fix warnings for regular 3-d grids

### DIFF
--- a/src/grid/grid_geometry_cartesian_3d.f90
+++ b/src/grid/grid_geometry_cartesian_3d.f90
@@ -149,17 +149,17 @@ contains
     i2 = locate(geo%w2,p%r%y)
     i3 = locate(geo%w3,p%r%z)
     if(i1<1.or.i1>geo%n1) then
-       call warn("find_cell","photon not in cell (in x direction)")
+       call warn("find_cell","photon not in grid (in x direction)")
        icell = invalid_cell
        return
     end if
     if(i2<1.or.i2>geo%n2) then
-       call warn("find_cell","photon not in cell (in y direction)")
+       call warn("find_cell","photon not in grid (in y direction)")
        icell = invalid_cell
        return
     end if
     if(i3<1.or.i3>geo%n3) then
-       call warn("find_cell","photon not in cell (in z direction)")
+       call warn("find_cell","photon not in grid (in z direction)")
        icell = invalid_cell
        return
     end if

--- a/src/grid/grid_geometry_cylindrical_3d.f90
+++ b/src/grid/grid_geometry_cylindrical_3d.f90
@@ -215,19 +215,19 @@ contains
     ! dimensions.
 
     if(i1<1.or.i1>geo%n1) then
-       call warn("find_cell","photon not in cell (in r direction)")
+       call warn("find_cell","photon not in grid (in r direction)")
        icell = invalid_cell
        return
     end if
 
     if(i2<1.or.i2>geo%n2) then
-       call warn("find_cell","photon not in cell (in z direction)")
+       call warn("find_cell","photon not in grid (in z direction)")
        icell = invalid_cell
        return
     end if
 
     if(i3<1.or.i3>geo%n3) then
-       call warn("find_cell","photon not in cell (in phi direction)")
+       call warn("find_cell","photon not in grid (in phi direction)")
        icell = invalid_cell
        return
     end if

--- a/src/grid/grid_geometry_spherical_3d.f90
+++ b/src/grid/grid_geometry_spherical_3d.f90
@@ -254,19 +254,19 @@ contains
     ! dimensions.
 
     if(i1<1.or.i1>geo%n1) then
-       call warn("find_cell","photon not in cell (in r direction)")
+       call warn("find_cell","photon not in grid (in r direction)")
        icell = invalid_cell
        return
     end if
 
     if(i2<1.or.i2>geo%n2) then
-       call warn("find_cell","photon not in cell (in theta direction)")
+       call warn("find_cell","photon not in grid (in theta direction)")
        icell = invalid_cell
        return
     end if
 
     if(i3<1.or.i3>geo%n3) then
-       call warn("find_cell","photon not in cell (in phi direction)")
+       call warn("find_cell","photon not in grid (in phi direction)")
        icell = invalid_cell
        return
     end if

--- a/src/grid/grid_geometry_voronoi.f90
+++ b/src/grid/grid_geometry_voronoi.f90
@@ -188,18 +188,38 @@ contains
   end subroutine grid_geometry_debug
 
   type(grid_cell) function find_cell(p) result(icell)
+
     implicit none
+
     type(photon),intent(in) :: p
     integer :: ic
     type(kdtree2_result) :: results(1)
     real(dp) :: point(3)
     if(debug) write(*,'(" [debug] find_cell")')
+
+    if(p%r%x<geo%xmin.or.p%r%x>geo%xmax) then
+       call warn("find_cell","photon not in grid (in x direction)")
+       icell = invalid_cell
+       return
+    end if
+    if(p%r%y<geo%ymin.or.p%r%y>geo%ymax) then
+       call warn("find_cell","photon not in grid (in y direction)")
+       icell = invalid_cell
+       return
+    end if
+    if(p%r%z<geo%zmin.or.p%r%z>geo%zmax) then
+       call warn("find_cell","photon not in grid (in z direction)")
+       icell = invalid_cell
+       return
+    end if
+
     ! TODO: nearest-neighbor algorithm - potentially going to be the
     ! bottleneck.
     point = [p%r%x, p%r%y, p%r%z]
     call kdtree2_n_nearest(geo%tree, point, 1, results)
     ic = results(1)%idx
     icell = new_grid_cell(ic, geo)
+
   end function find_cell
 
   subroutine place_in_cell(p)


### PR DESCRIPTION
Output is now:

```
 [grid_physics] pre-computing jnu_var
 
        # Photons    CPU time (sec)    Photons/sec  
      ----------------------------------------------
 WARNING: photon not in grid (in x direction) [find_cell]
 WARNING: place_in_cell failed - killing [place_in_cell]
 ------------------------------------------------------------------------
 ERROR   : photon was not emitted inside a cell - this usually indicates 
           that a source is not inside the grid
 WHERE   : emit
 ------------------------------------------------------------------------
 
  *** Execution aborted on 05 March 2015 at 12:27:35 ***
```