### PR TITLE
Sparse neighbours

### DIFF
--- a/hyperion/grid/_voronoi_core.c
+++ b/hyperion/grid/_voronoi_core.c
@@ -5,7 +5,7 @@
 #include <numpy/npy_math.h>
 
 // Declaration of the voro++ wrapping function.
-const char *hyperion_voropp_wrap(int **neighbours, int **sparse_neighbours, int **neigh_pos, int *nn, int *max_nn, double **volumes, double **bb_min, double **bb_max, double **vertices, int *max_nv,
+const char *hyperion_voropp_wrap(int **sparse_neighbours, int **neigh_pos, int *nn, double **volumes, double **bb_min, double **bb_max, double **vertices, int *max_nv,
                   double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, double const *points, int npoints, int with_vertices, const char *wall_str, const double *wall_args_arr,
                   int n_wall_args, int with_sampling, int n_samples, double **sample_points, int **sampling_idx, int *tot_samples, int min_cell_samples, int verbose);
 
@@ -100,11 +100,11 @@ static PyObject *_voropp_wrapper(PyObject *self, PyObject *args)
     int nsites = (int)PyArray_DIM(s_array, 0);
 
     double *volumes = NULL, *bb_min = NULL, *bb_max = NULL, *vertices = NULL, *sample_points = NULL;
-    int *neighbours = NULL, *sampling_idx = NULL, *sparse_neighbours = NULL, *neigh_pos = NULL;
-    int max_nn, max_nv, tot_samples, nn;
+    int *sampling_idx = NULL, *sparse_neighbours = NULL, *neigh_pos = NULL;
+    int max_nv, tot_samples, nn;
 
     // Call the wrapper.
-    const char *status = hyperion_voropp_wrap(&neighbours,&sparse_neighbours,&neigh_pos,&nn,&max_nn,&volumes,&bb_min,&bb_max,&vertices,&max_nv,
+    const char *status = hyperion_voropp_wrap(&sparse_neighbours,&neigh_pos,&nn,&volumes,&bb_min,&bb_max,&vertices,&max_nv,
                                               d_data[0],d_data[1],d_data[2],d_data[3],d_data[4],d_data[5],s_data,nsites,with_vertices,
                                               wall_str,wall_args_arr,n_wall_args,with_sampling,n_samples,&sample_points,&sampling_idx,
                                               &tot_samples,min_cell_samples,verbose
@@ -122,7 +122,6 @@ static PyObject *_voropp_wrapper(PyObject *self, PyObject *args)
     // http://blog.enthought.com/python/numpy-arrays-with-pre-allocated-memory
     // We will just create new numpy arrays and return them for now.
     npy_intp vol_dims[] = {nsites};
-    npy_intp neigh_dims[] = {nsites,max_nn};
     npy_intp bb_dims[] = {nsites,3};
     npy_intp vert_dims[] = {nsites,max_nv};
     npy_intp spoints_dims[] = {tot_samples,3};
@@ -131,7 +130,6 @@ static PyObject *_voropp_wrapper(PyObject *self, PyObject *args)
     npy_intp neigh_pos_dims[] = {nsites + 1};
 
     PyObject *vol_array = PyArray_SimpleNew(1,vol_dims,NPY_DOUBLE);
-    PyObject *neigh_array = PyArray_SimpleNew(2,neigh_dims,NPY_INT);
     PyObject *bb_min_array = PyArray_SimpleNew(2,bb_dims,NPY_DOUBLE);
     PyObject *bb_max_array = PyArray_SimpleNew(2,bb_dims,NPY_DOUBLE);
     // NOTE: Py_BuildValue("") is just a safe way to construct None.
@@ -141,11 +139,10 @@ static PyObject *_voropp_wrapper(PyObject *self, PyObject *args)
     PyObject *sparse_neigh_array = PyArray_SimpleNew(1,sparse_neigh_dims,NPY_INT);
     PyObject *neigh_pos_array = PyArray_SimpleNew(1,neigh_pos_dims,NPY_INT);
 
-    if (vol_array == NULL || neigh_array == NULL || bb_min_array == NULL || bb_max_array == NULL ||
+    if (vol_array == NULL || bb_min_array == NULL || bb_max_array == NULL ||
         vert_array == NULL || spoints_array == NULL || spoints_idx_array == NULL || sparse_neigh_array == NULL || neigh_pos_array == NULL)
     {
         PyErr_SetString(PyExc_MemoryError, "Memory allocation error.");
-        free(neighbours);
         free(volumes);
         free(bb_min);
         free(bb_max);
@@ -157,7 +154,6 @@ static PyObject *_voropp_wrapper(PyObject *self, PyObject *args)
         Py_XDECREF(s_array);
         Py_XDECREF(d_array);
         Py_XDECREF(vol_array);
-        Py_XDECREF(neigh_array);
         Py_XDECREF(bb_min_array);
         Py_XDECREF(bb_max_array);
         Py_XDECREF(vert_array);
@@ -170,7 +166,6 @@ static PyObject *_voropp_wrapper(PyObject *self, PyObject *args)
 
     // Copy over the data.
     memcpy((double*)PyArray_DATA(vol_array),volumes,sizeof(double) * nsites);
-    memcpy((int*)PyArray_DATA(neigh_array),neighbours,sizeof(int) * nsites * max_nn);
     memcpy((double*)PyArray_DATA(bb_min_array),bb_min,sizeof(double) * nsites * 3);
     memcpy((double*)PyArray_DATA(bb_max_array),bb_max,sizeof(double) * nsites * 3);
     if (with_vertices) {
@@ -183,10 +178,9 @@ static PyObject *_voropp_wrapper(PyObject *self, PyObject *args)
     memcpy((int*)PyArray_DATA(sparse_neigh_array),sparse_neighbours,sizeof(int) * nn);
     memcpy((int*)PyArray_DATA(neigh_pos_array),neigh_pos,sizeof(int) * (nsites + 1));
 
-    PyObject *retval = PyTuple_Pack(9,sparse_neigh_array,neigh_pos_array,neigh_array,vol_array,bb_min_array,bb_max_array,vert_array,spoints_array,spoints_idx_array);
+    PyObject *retval = PyTuple_Pack(8,sparse_neigh_array,neigh_pos_array,vol_array,bb_min_array,bb_max_array,vert_array,spoints_array,spoints_idx_array);
 
     // Final cleanup.
-    free(neighbours);
     free(volumes);
     free(bb_min);
     free(bb_max);
@@ -199,7 +193,6 @@ static PyObject *_voropp_wrapper(PyObject *self, PyObject *args)
     Py_XDECREF(d_array);
     // NOTE: these need to be cleaned up as PyTuple_Pack will increment the reference count. See:
     // https://mail.python.org/pipermail/capi-sig/2009-February/000222.html
-    Py_XDECREF(neigh_array);
     Py_XDECREF(vol_array);
     Py_XDECREF(bb_min_array);
     Py_XDECREF(bb_max_array);

--- a/hyperion/grid/tests/test_voronoi.py
+++ b/hyperion/grid/tests/test_voronoi.py
@@ -19,7 +19,13 @@ DATA = os.path.join(os.path.dirname(__file__), 'data')
 # could have extra neighbours due to the clipping of the domain
 # by voro++.
 def _neighbours_check(voro, qhull):
-    return all([all([_ in set(filter(lambda n: n >= 0, tup[0]))] for _ in filter(lambda n: n >= 0, tup[1])) for tup in zip(qhull['neighbours'], voro['neighbours'])])
+    idx = voro.st[1]
+    vneighs = voro.st[0]
+    for i in range(len(idx) - 1):
+        cur_neighs = filter(lambda n: n >= 0,vneighs[idx[i]:idx[i+1]])
+        if not all([_ in qhull['neighbours'][i] for _ in cur_neighs]):
+            return False
+    return True
 
 # Check that the volumes are positive and amount to the total domain volume.
 
@@ -56,15 +62,9 @@ def test_consistency():
         vg = vh.voronoi_grid(sites_arr, np.array([[0, 1.], [0, 1], [0, 1]]))
         voro = vg.neighbours_table
         qhull = Table.read(os.path.join(DATA, s), path='data')
-        assert _neighbours_check(voro, qhull)
+        assert _neighbours_check(vg, qhull)
         assert _volume_check(voro)
         assert _bb_check(voro)
-        # Check that the sparse representation is consistent with the dense one.
-        assert len(vg.st[1]) == 10 ** (idx + 1) + 1
-        for i in range(10 ** (idx + 1)):
-            # The dense array of neighbours.
-            na = vg.neighbours_table[i]['neighbours']
-            assert all(vg.st[0][vg.st[1][i]:vg.st[1][i+1]] == na[na != -10])
 
 def test_evaluate_function_average():
 

--- a/hyperion/grid/tests/test_voronoi.py
+++ b/hyperion/grid/tests/test_voronoi.py
@@ -59,7 +59,12 @@ def test_consistency():
         assert _neighbours_check(voro, qhull)
         assert _volume_check(voro)
         assert _bb_check(voro)
-
+        # Check that the sparse representation is consistent with the dense one.
+        assert len(vg.st[1]) == 10 ** (idx + 1) + 1
+        for i in range(10 ** (idx + 1)):
+            # The dense array of neighbours.
+            na = vg.neighbours_table[i]['neighbours']
+            assert all(vg.st[0][vg.st[1][i]:vg.st[1][i+1]] == na[na != -10])
 
 def test_evaluate_function_average():
 

--- a/hyperion/grid/voronoi_grid.py
+++ b/hyperion/grid/voronoi_grid.py
@@ -457,7 +457,7 @@ class VoronoiGrid(FreezableClass):
         voronoi_table['volume'][np.isinf(voronoi_table['volume'])] = -1.
 
         # Remove the dense neighbours from the table.
-        voronoi_table = Table([voronoi_table['coordinates'],voronoi_table['volume'],voronoi_table['bb_min'],voronoi_table['bb_max']])
+        voronoi_table = voronoi_table['coordinates', 'volume', 'bb_min', 'bb_max']
 
         # Create new tables from the sparse representation of the neighbours, with indices.
         snt = Table(data = [self._st[0]],names=['sparse_neighs'])

--- a/hyperion/grid/voronoi_grid.py
+++ b/hyperion/grid/voronoi_grid.py
@@ -423,6 +423,7 @@ class VoronoiGrid(FreezableClass):
         '''
 
         from astropy.table import Table
+        import numpy as np
 
         # Create HDF5 groups if needed
 
@@ -456,14 +457,10 @@ class VoronoiGrid(FreezableClass):
         voronoi_table['volume'][np.isnan(voronoi_table['volume'])] = -1.
         voronoi_table['volume'][np.isinf(voronoi_table['volume'])] = -1.
 
-        # Create new tables from the sparse representation of the neighbours, with indices.
-        snt = Table(data = [self._st[0]],names=['sparse_neighs'])
-        sit = Table(data = [self._st[1]],names=['sparse_idx'])
-
         # Write the tables.
-        voronoi_table.write(g_geometry, path="cells", compression=True)
-        snt.write(g_geometry, path="sparse_neighs", compression=True)
-        sit.write(g_geometry, path="sparse_idx", compression=True)
+        voronoi_table.write(g_geometry, path='cells', compression=True)
+        g_geometry.create_dataset('sparse_neighs', data = self._st[0], compression = True)
+        g_geometry.create_dataset('sparse_idx', data = self._st[1], compression = True)
 
         # Self-consistently check geometry and physical quantities
         self._check_array_dimensions()

--- a/hyperion/grid/voronoi_grid.py
+++ b/hyperion/grid/voronoi_grid.py
@@ -456,9 +456,6 @@ class VoronoiGrid(FreezableClass):
         voronoi_table['volume'][np.isnan(voronoi_table['volume'])] = -1.
         voronoi_table['volume'][np.isinf(voronoi_table['volume'])] = -1.
 
-        # Remove the dense neighbours from the table.
-        voronoi_table = voronoi_table['coordinates', 'volume', 'bb_min', 'bb_max']
-
         # Create new tables from the sparse representation of the neighbours, with indices.
         snt = Table(data = [self._st[0]],names=['sparse_neighs'])
         sit = Table(data = [self._st[1]],names=['sparse_idx'])

--- a/hyperion/grid/voronoi_helpers.py
+++ b/hyperion/grid/voronoi_helpers.py
@@ -124,7 +124,8 @@ class voronoi_grid(object):
             self._samples = tup[-2]
             self._samples_idx = tup[-1]
             tup = tup[0:-2]
-        t = Table([sites] + list(filter(lambda _: not _ is None,tup)),names=tuple(names))
+        t = Table([sites] + list(filter(lambda _: not _ is None,tup[2:])),names=tuple(names))
+        self.st = tup[0:2]
 
         self._neighbours_table = t
 

--- a/hyperion/grid/voronoi_helpers.py
+++ b/hyperion/grid/voronoi_helpers.py
@@ -117,7 +117,7 @@ class voronoi_grid(object):
         with_sampling = 1 if n_samples > 0 else 0
         tup = _voropp_wrapper(sites, domain, with_vertices, wall, wall_args, with_sampling, n_samples,
                               min_cell_samples, 1 if verbose else 0)
-        names = ['coordinates', 'neighbours', 'volume', 'bb_min', 'bb_max']
+        names = ['coordinates', 'volume', 'bb_min', 'bb_max']
         if with_vertices:
             names.append('vertices')
         if with_sampling:

--- a/hyperion/grid/voropp_wrap.cc
+++ b/hyperion/grid/voropp_wrap.cc
@@ -14,7 +14,7 @@
 
 #include "voro++/voro++.hh"
 
-extern "C" const char * hyperion_voropp_wrap(int **neighbours, int **sparse_neighbours, int **neigh_pos, int *nn, int *max_nn, double **volumes, double **bb_min, double **bb_max, double **vertices,
+extern "C" const char * hyperion_voropp_wrap(int **sparse_neighbours, int **neigh_pos, int *nn, double **volumes, double **bb_min, double **bb_max, double **vertices,
                                              int *max_nv, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax,
                                              double const *points, int npoints, int with_vertices, const char *wall_str, const double *wall_args_arr, int n_wall_args,
                                              int with_sampling, int n_samples, double **sample_points, int **sampling_idx, int *tot_samples, int min_cell_samples,
@@ -167,7 +167,7 @@ static inline void sample_point_in_tetra(Ptr res,It p0, It p1, It p2, It p3)
 }
 
 // Main wrapper called from cpython.
-const char *hyperion_voropp_wrap(int **neighbours, int **sparse_neighbours, int **neigh_pos, int *nn, int *max_nn, double **volumes, double **bb_min, double **bb_max, double **vertices,
+const char *hyperion_voropp_wrap(int **sparse_neighbours, int **neigh_pos, int *nn, double **volumes, double **bb_min, double **bb_max, double **vertices,
                                  int *max_nv, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax, double const *points,
                                  int nsites, int with_vertices, const char *wall_str, const double *wall_args_arr, int n_wall_args, int with_sampling, int n_samples,
                                  double **sample_points, int **sampling_idx, int *tot_samples, int min_cell_samples, int verbose)
@@ -265,6 +265,9 @@ const char *hyperion_voropp_wrap(int **neighbours, int **sparse_neighbours, int 
     std::vector<double> cc_vol;
     cc_vol.push_back(0);
 
+    // Init the total number of neighbours.
+    *nn = 0;
+
     // Loop over all particles and compute the desired quantities.
     if(vl.start()) {
         do {
@@ -275,6 +278,8 @@ const char *hyperion_voropp_wrap(int **neighbours, int **sparse_neighbours, int 
             con.compute_cell(c,vl);
             // Compute the neighbours.
             c.neighbors(n_list[idx]);
+            // Update the number of neighbours.
+            *nn += n_list[idx].size();
             // Volume.
             vols.get()[idx] = c.volume();
             // Compute bounding box. Start by asking for the vertices.
@@ -412,40 +417,19 @@ const char *hyperion_voropp_wrap(int **neighbours, int **sparse_neighbours, int 
         }
     }
 
+    // Allocate space for the sparse version of the neighbour indices.
+    ptr_raii<int> sparse_neighs(static_cast<int *>(std::malloc(sizeof(int) * (*nn))));
+    ptr_raii<int> sparse_neighs_indices(static_cast<int *>(std::malloc(sizeof(int) * (nsites + 1))));
     // Build the sparse version of the neighbours list.
-    std::vector<int> sparse_n_list, n_pos;
     int cur_idx = 0;
     for (std::size_t i = 0u; i < n_list.size(); ++i) {
         const std::vector<int> &v = n_list[i];
-        sparse_n_list.insert(sparse_n_list.end(),v.begin(),v.end());
-        n_pos.push_back(cur_idx);
+        std::copy(v.begin(),v.end(),sparse_neighs.get() + cur_idx);
+        *(sparse_neighs_indices.get() + i) = cur_idx;
         cur_idx += v.size();
     }
-    // Push back the last index.
-    n_pos.push_back(cur_idx);
-    // Set the total number of neighbours.
-    *nn = sparse_n_list.size();
-
-    // Compute the max number of neighbours.
-    *max_nn = std::max_element(n_list.begin(),n_list.end(),size_cmp<int>)->size();
-    if (verbose) std::cout << "Max number of neighbours is: " << *max_nn << '\n';
-
-    // Allocate space for flat array of neighbours.
-    ptr_raii<int> neighs(static_cast<int *>(std::malloc(sizeof(int) * nsites * (*max_nn))));
-    // Fill it in.
-    for (idx = 0; idx < nsites; ++idx) {
-        int *ptr = neighs.get() + (*max_nn) * idx;
-        std::copy(n_list[idx].begin(),n_list[idx].end(),ptr);
-        // Fill empty elements with -10.
-        std::fill(ptr + n_list[idx].size(),ptr + (*max_nn),-10);
-    }
-
-    // Allocate space for the sparse version of the neighbour indices.
-    ptr_raii<int> sparse_neighs(static_cast<int *>(std::malloc(sizeof(int) * sparse_n_list.size())));
-    ptr_raii<int> sparse_neighs_indices(static_cast<int *>(std::malloc(sizeof(int) * n_pos.size())));
-    // Fill them in.
-    std::copy(sparse_n_list.begin(),sparse_n_list.end(),sparse_neighs.get());
-    std::copy(n_pos.begin(),n_pos.end(),sparse_neighs_indices.get());
+    // Last index.
+    *(sparse_neighs_indices.get() + nsites) = cur_idx;
 
     if (with_vertices) {
         // Compute the max number of vertices coordinates.
@@ -472,7 +456,6 @@ const char *hyperion_voropp_wrap(int **neighbours, int **sparse_neighbours, int 
     *volumes = vols.release();
     *bb_min = bb_m.release();
     *bb_max = bb_M.release();
-    *neighbours = neighs.release();
     *sample_points = spoints.release();
     *sampling_idx = spoints_idx.release();
     *sparse_neighbours = sparse_neighs.release();

--- a/src/grid/grid_geometry_voronoi.f90
+++ b/src/grid/grid_geometry_voronoi.f90
@@ -113,8 +113,8 @@ contains
     call mp_table_read_column_auto(group, 'cells', 'coordinates', points)
     call mp_table_read_column_auto(group, 'cells', 'bb_min', bb_min)
     call mp_table_read_column_auto(group, 'cells', 'bb_max', bb_max)
-    call mp_table_read_column_auto(group, 'sparse_neighs', 'sparse_neighs', sparse_neighs)
-    call mp_table_read_column_auto(group, 'sparse_idx', 'sparse_idx', sparse_idx)
+    call hdf5_read_array_auto(group, 'sparse_neighs', sparse_neighs)
+    call hdf5_read_array_auto(group, 'sparse_idx', sparse_idx)
 
     allocate(x(size(points,2)))
     allocate(y(size(points,2)))

--- a/src/grid/grid_geometry_voronoi.f90
+++ b/src/grid/grid_geometry_voronoi.f90
@@ -98,10 +98,10 @@ contains
 
     integer(hid_t),intent(in) :: group
 
-    integer :: ic, iv
-    real(dp), allocatable :: x(:), y(:), z(:)
-    integer, allocatable :: neighbors(:,:)
+    integer :: ic, iv, is
     integer :: n_neighbors
+    real(dp), allocatable :: x(:), y(:), z(:)
+    integer, allocatable :: sparse_neighs(:), sparse_idx(:)
     real(dp),allocatable :: bb_min(:,:), bb_max(:,:)
     type(cell),pointer :: c
 
@@ -111,9 +111,10 @@ contains
 
     ! Read in list of cells
     call mp_table_read_column_auto(group, 'cells', 'coordinates', points)
-    call mp_table_read_column_auto(group, 'cells', 'neighbours', neighbors)
     call mp_table_read_column_auto(group, 'cells', 'bb_min', bb_min)
     call mp_table_read_column_auto(group, 'cells', 'bb_max', bb_max)
+    call mp_table_read_column_auto(group, 'sparse_neighs', 'sparse_neighs', sparse_neighs)
+    call mp_table_read_column_auto(group, 'sparse_idx', 'sparse_idx', sparse_idx)
 
     allocate(x(size(points,2)))
     allocate(y(size(points,2)))
@@ -131,14 +132,20 @@ contains
     allocate(geo%cells(geo%n_cells))
 
     ! Assigned refined values to all cells
+    is = 1
     do ic=1,geo%n_cells
        geo%cells(ic)%r%x = x(ic)
        geo%cells(ic)%r%y = y(ic)
        geo%cells(ic)%r%z = z(ic)
-       ! Indices from -1 to -6 included are the walls of the rectangular domain.
-       n_neighbors = count(neighbors(:, ic) >= -6)
+       ! Determine the number of neighbors from the sparse idx array.
+       n_neighbors = sparse_idx(is+1) - sparse_idx(is)
        allocate(geo%cells(ic)%neighbors(n_neighbors))
-       geo%cells(ic)%neighbors(1:n_neighbors) = neighbors(1:n_neighbors, ic) + 1
+       ! All these +1s are due to the difference in array indexing between Fortran and C/Python.
+       ! Specifically:
+       ! - sparse_idx(is) + 1 because sparse_idx is an array of C-style indices,
+       ! - sparse_neighs(...) + 1 because the neighbour indices are C-style.
+       geo%cells(ic)%neighbors(1:n_neighbors) = sparse_neighs(sparse_idx(is) + 1:sparse_idx(is + 1) + 1) + 1
+       is = is + 1
     end do
 
     ! Construct KDTree
@@ -358,7 +365,7 @@ contains
         if (icell%neighbors(i) <= 0 .and. icell%neighbors(i) >= -5) then
             select case (icell%neighbors(i))
                 case (0)
-                    ! Note that here we are checking indices from 0 to -5 (instead of -1 to -6 as in the 
+                    ! Note that here we are checking indices from 0 to -5 (instead of -1 to -6 as in the
                     ! original voro++ convention) because of the indexing offset introduced by Fortran notation.
                     ! xmin wall
                     if (p%v%x < 0._dp) call insert_t(( geo%xmin - p%r%x ) / p%v%x, 1, geo%n_cells + 1, 0._dp)


### PR DESCRIPTION
Here is the initial implementation of the sparse representation of the neighbours.

The ``voronoi_grid`` class in ``voronoi_helpers.py`` now has an extra attribute, called ``st`` (sparse table). This is a tuple of 2 elements: the list of all neighbours of all cells, and a list of indices specifying at what points in the first list the neighbours for the n-th cell start. This second list always has a size of ``nsites + 1``, while the first list has a size that depends on the initial distribution of the sites.

Example: ``st[0]`` is ``[0,2,3,4,6,1,4,5,6,4,3]`` and ``st[1]`` is ``[0,3,4,11]``. This means that:

* cell 0 has neighbours ``[0,2,3]``,
* cell 1 has neighbours ``[4]``,
* cell 2 has neighbours ``[6,1,4,5,6,4,3]``.

The previous dense representation is available as before in the ``neighbours_table`` attribute. I have added some checks to the existing test code in order to make sure that the sparse representation is consistent with the dense one.

I also made some optimisations to the initial setup of the tessellation on the Python side (specifically, the check that all sites are within the domain boundaries is now done in numpy and hence much faster).