### PR TITLE
clang: error: unknown argument: '-mno-fused-madd' [-Wunused-command-line-argument-hard-error-in-future]

### DIFF
--- a/docs/installation/python_dependencies.rst
+++ b/docs/installation/python_dependencies.rst
@@ -172,3 +172,17 @@ Finally, check that Astropy imports cleanly::
     Type "help", "copyright", "credits" or "license" for more information.
     >>> import astropy
     >>>
+
+Known issues
+============
+
+On recent versions of MacOS X, you may encounter the following error when trying
+to install the Python library for Hyperion::
+
+    clang: error: unknown argument: '-mno-fused-madd' [-Wunused-command-line-argument-hard-error-in-future]
+
+If this is the case, try setting the following environment variables before
+installing it::
+
+    export CFLAGS=-Qunused-arguments
+    export CPPFLAGS=-Qunused-arguments


### PR DESCRIPTION
In some cases the compilation can error with:

```
clang: error: unknown argument: '-mno-fused-madd' [-Wunused-command-line-argument-hard-error-in-future]
```

We should add a known issue to the docs and point out it can be solved by doing:

```
export CFLAGS=-Qunused-arguments
export CPPFLAGS=-Qunused-arguments
```