### PR TITLE
If using binned images, Python code should raise warning about forced first scattering

### DIFF
--- a/hyperion/model/model.py
+++ b/hyperion/model/model.py
@@ -572,6 +572,8 @@ class Model(FreezableClass, RunConf):
 
         # Output configuration for binned images/SEDs
         if self.binned_output is not None:
+            if self.forced_first_scattering:
+                raise Exception("can't use binned images with forced first scattering - use set_forced_first_scattering(False) to disable")
             self.binned_output.write(g_binned.create_group('group_00001'))
 
         # Write monochromatic configuration
@@ -914,7 +916,7 @@ class Model(FreezableClass, RunConf):
         self.peeled_output[-1]._set_monochromatic(self._monochromatic, frequencies=self._frequencies)
         return self.peeled_output[-1]
 
-    def add_binned_images(self, **kwargs):
+    def add_binned_images(self, sed=True, image=True):
         """
         Define a set of (binned) images/SEDs.
 

--- a/hyperion/model/tests/test_model.py
+++ b/hyperion/model/tests/test_model.py
@@ -371,3 +371,20 @@ def test_model_minimal(tmpdir):
     m.set_n_photons(imaging=10)
     m.write(tmpdir.join(random_id()).strpath)
     m.run()
+
+
+def test_binned_forced_first_scattering(tmpdir):
+
+    m = Model()
+
+    m.set_cartesian_grid([-1., 1.], [-1., 1.], [-1., 1.])
+
+    i = m.add_binned_images(sed=True, image=False)
+    i.set_wavelength_range(5, 1, 10)
+    i.set_viewing_bins(2, 2)
+
+    m.set_n_photons(initial=100, imaging=100)
+
+    with pytest.raises(Exception) as exc:
+        m.write(tmpdir.join(random_id()).strpath)
+    assert exc.value.args[0] == "can't use binned images with forced first scattering - use set_forced_first_scattering(False) to disable"


### PR DESCRIPTION
Rather than wait until the Fortran code raises it:

```
 ------------------------------------------------------------------------
 ERROR   : can't use binned images with forced first scattering
 WHERE   : setup_final_iteration
 ------------------------------------------------------------------------
 ```