### PR TITLE
Fix AMR set-up bug

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,9 @@ Version History
 
 - Fixed bug in ordering of axes for Cartesian and AMR grids for yt 3.x. [#168]
 
+- Fixed a severe bug in the set-up of AMR grids that caused photons to be
+  terminated before escaping from grids in specific cases. [#167]
+
 0.9.7 (2015-08-22)
 ------------------
 

--- a/hyperion/model/tests/test_amr_checks.py
+++ b/hyperion/model/tests/test_amr_checks.py
@@ -1,10 +1,15 @@
 from astropy.tests.helper import pytest
 import numpy as np
 
-from .. import Model
+from .. import Model, ModelOutput
 from .test_helpers import random_id, get_test_dust
 from ...grid import AMRGrid
 
+try:
+    import yt
+    YT_INSTALLED = True
+except ImportError:
+    YT_INSTALLED = False
 
 @pytest.mark.parametrize(('direction'), ['x', 'y', 'z'])
 def test_amr_differing_widths(tmpdir, direction):
@@ -166,3 +171,58 @@ def test_amr_not_aligned_across_levels(tmpdir, direction):
     assert exc.value.args[0] == 'An error occurred, and the run did not ' + \
                                 'complete'
     assert ('Grid 1 in level 2 is not aligned with cells in level 1 in the \n           %s direction' % direction) in open(log_file).read()
+
+
+@pytest.mark.skipif("not YT_INSTALLED")
+def test_shadowing_regression(tmpdir):
+
+    # Regression test for a bug that caused photons escaping from some grids to
+    # be terminated.
+
+    amr = AMRGrid()
+
+    level = amr.add_level()
+
+    grid = level.add_grid()
+    grid.xmin, grid.xmax = -1, 1
+    grid.ymin, grid.ymax = -1, 1
+    grid.zmin, grid.zmax = -1, 1
+    grid.nx, grid.ny, grid.nz = 8, 8, 8
+    grid.quantities['density'] = np.ones((grid.nz, grid.ny, grid.nx))
+
+    level = amr.add_level()
+
+    grid = level.add_grid()
+    grid.xmin, grid.xmax = 0.5, 1
+    grid.ymin, grid.ymax = -0.5, 0.5
+    grid.zmin, grid.zmax = -0.5, 0.5
+    grid.nx, grid.ny, grid.nz = 4, 8, 8
+    grid.quantities['density'] = np.ones((grid.nz, grid.ny, grid.nx))
+
+    m = Model()
+
+    m.set_grid(amr)
+
+    m.add_density_grid(amr['density'], get_test_dust())
+
+    s = m.add_point_source()
+    s.luminosity = 100
+    s.temperature = 10000
+    s.position = (0.0001, 0.0001, 0.0001)
+
+    m.set_n_photons(initial=1e5, imaging=0)
+
+    m.write(tmpdir.join(random_id()).strpath)
+    mo = m.run(tmpdir.join(random_id()).strpath)
+
+    from yt.mods import SlicePlot
+
+    g = mo.get_quantities()
+
+    pf = g.to_yt()
+
+    prj = SlicePlot(pf, 'y', ['density', 'temperature'],
+                         center=[0.0, 0.0, 0.0])
+
+    # With bug, value was lower because there were shadowed regions
+    assert 12. < prj.frb['temperature'].min().value < 13.

--- a/hyperion/model/tests/test_amr_checks.py
+++ b/hyperion/model/tests/test_amr_checks.py
@@ -180,8 +180,10 @@ def test_amr_not_aligned_across_levels(tmpdir, direction):
     assert ('Grid 1 in level 2 is not aligned with cells in level 1 in the \n           %s direction' % direction) in open(log_file).read()
 
 
-@pytest.mark.skipif("YT_VERSION is None or YT_VERSION < 3")
+@pytest.mark.skipif("YT_VERSION is None")
 def test_shadowing_regression(tmpdir):
+
+    from ...grid.tests.yt_compat import get_frb
 
     # Regression test for a bug that caused photons escaping from some grids to
     # be terminated.
@@ -232,4 +234,4 @@ def test_shadowing_regression(tmpdir):
                          center=[0.0, 0.0, 0.0])
 
     # With bug, value was lower because there were shadowed regions
-    assert 12. < prj.frb['temperature'].min().value < 13.
+    assert 12. < get_frb(prj, 'temperature').min() < 13.

--- a/hyperion/model/tests/test_amr_checks.py
+++ b/hyperion/model/tests/test_amr_checks.py
@@ -1,3 +1,5 @@
+from distutils.version import LooseVersion
+
 from astropy.tests.helper import pytest
 import numpy as np
 
@@ -7,9 +9,14 @@ from ...grid import AMRGrid
 
 try:
     import yt
-    YT_INSTALLED = True
-except ImportError:
-    YT_INSTALLED = False
+except:
+    YT_VERSION = None
+else:
+    if LooseVersion(yt.__version__) >= LooseVersion('3'):
+        YT_VERSION = 3
+    else:
+        YT_VERSION = 2
+
 
 @pytest.mark.parametrize(('direction'), ['x', 'y', 'z'])
 def test_amr_differing_widths(tmpdir, direction):
@@ -173,7 +180,7 @@ def test_amr_not_aligned_across_levels(tmpdir, direction):
     assert ('Grid 1 in level 2 is not aligned with cells in level 1 in the \n           %s direction' % direction) in open(log_file).read()
 
 
-@pytest.mark.skipif("not YT_INSTALLED")
+@pytest.mark.skipif("YT_VERSION is None or YT_VERSION < 3")
 def test_shadowing_regression(tmpdir):
 
     # Regression test for a bug that caused photons escaping from some grids to

--- a/src/grid/grid_geometry_amr.f90
+++ b/src/grid/grid_geometry_amr.f90
@@ -392,7 +392,7 @@ contains
              do igrid2=1,size(level2%grids)
                 grid2 => level2%grids(igrid2)
 
-                if(grids_close(grid1, grid2).and.igrid1.ne.igrid2) then
+                if(grids_close(grid1, grid2).and.(igrid1.ne.igrid2 .or. ilevel1.ne.ilevel2)) then
 
                    ! xmin side
                    i1 = 0


### PR DESCRIPTION
Fixed a severe bug in the set-up of AMR grids that caused photons to be terminated before escaping from grids in specific cases.