### PR TITLE
Workaround for an Intel Fortran compiler bug (in v16)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,8 @@ Version History
 0.9.9 (unreleased)
 ------------------
 
+- Added a workaround for a bug in ifort v16 that prevented compilation. [#190]
+
 - Improved the accuracy of the Wood and Reynolds (1999) forced first scattering
   algorithm for very small optical depths, and implemented the Baes et al (2016)
   composite biasing algorithm for forced first interaction. In addition, the

--- a/src/core/type_cell_id_3d.f90
+++ b/src/core/type_cell_id_3d.f90
@@ -13,10 +13,15 @@ module type_grid_cell
 
   type(grid_cell),parameter,public :: invalid_cell = grid_cell(-1,-1,-1,-1)
 
+  ! Note: if one of the module procedures for .eq. is called equal, this causes
+  !       issues with ifort 16 due a bug (because lib_version also defines
+  !       equal). Therefore, we call the functions equal_grid_cell and
+  !       equall_wall_id instead.
+
   public :: operator(.eq.)
   interface operator(.eq.)
-     module procedure equal
-     module procedure equal_wall
+     module procedure equal_grid_cell
+     module procedure equal_wall_id
   end interface operator(.eq.)
 
   public :: operator(+)
@@ -39,11 +44,11 @@ module type_grid_cell
 
 contains
 
-  logical function equal_wall(a,b)
+  logical function equal_wall_id(a,b)
     implicit none
     type(wall_id), intent(in) :: a,b
-    equal_wall = a%w1 == b%w1 .and. a%w2 == b%w2 .and. a%w3 == b%w3
-  end function equal_wall
+    equal_wall_id = a%w1 == b%w1 .and. a%w2 == b%w2 .and. a%w3 == b%w3
+  end function equal_wall_id
 
   type(wall_id) function add_wall(a,b) result(c)
     implicit none
@@ -53,11 +58,11 @@ contains
     c%w3 = a%w3 + b%w3
   end function add_wall
 
-  logical function equal(a,b)
+  logical function equal_grid_cell(a,b)
     implicit none
     type(grid_cell), intent(in) :: a,b
-    equal = a%i1 == b%i1 .and. a%i2 == b%i2 .and. a%i3 == b%i3
-  end function equal
+    equal_grid_cell = a%i1 == b%i1 .and. a%i2 == b%i2 .and. a%i3 == b%i3
+  end function equal_grid_cell
 
   type(grid_cell) function new_grid_cell_3d(i1, i2, i3, geo) result(cell)
     implicit none

--- a/src/core/type_cell_id_amr.f90
+++ b/src/core/type_cell_id_amr.f90
@@ -18,10 +18,15 @@ module type_grid_cell
   type(grid_cell),parameter,public :: invalid_cell = grid_cell(-1, -1, -1, -1, -1, -1)
   type(grid_cell),parameter,public :: outside_cell = grid_cell(-2, -2, -2, -2, -2, -2)
 
+  ! Note: if one of the module procedures for .eq. is called equal, this causes
+  !       issues with ifort 16 due a bug (because lib_version also defines
+  !       equal). Therefore, we call the functions equal_grid_cell and
+  !       equall_wall_id instead.
+
   public :: operator(.eq.)
   interface operator(.eq.)
-     module procedure equal
-     module procedure equal_wall
+     module procedure equal_grid_cell
+     module procedure equal_wall_id
   end interface operator(.eq.)
 
   public :: new_grid_cell
@@ -42,11 +47,11 @@ module type_grid_cell
 
 contains
 
-  logical function equal_wall(a,b)
+  logical function equal_wall_id(a,b)
     implicit none
     type(wall_id), intent(in) :: a,b
-    equal_wall = a%w1 == b%w1 .and. a%w2 == b%w2 .and. a%w3 == b%w3
-  end function equal_wall
+    equal_wall_id = a%w1 == b%w1 .and. a%w2 == b%w2 .and. a%w3 == b%w3
+  end function equal_wall_id
 
   subroutine preset_cell_id(geo)
 
@@ -85,11 +90,11 @@ contains
 
   end subroutine preset_cell_id
 
-  logical function equal(a,b)
+  logical function equal_grid_cell(a,b)
     implicit none
     type(grid_cell), intent(in) :: a,b
-    equal = a%ic == b%ic
-  end function equal
+    equal_grid_cell = a%ic == b%ic
+  end function equal_grid_cell
 
   type(grid_cell) function new_grid_cell_5d(i1, i2, i3, ilevel, igrid, geo) result(cell)
     implicit none

--- a/src/core/type_cell_id_octree.f90
+++ b/src/core/type_cell_id_octree.f90
@@ -12,10 +12,15 @@ module type_grid_cell
 
   type(grid_cell),parameter,public :: invalid_cell = grid_cell(-1)
 
+  ! Note: if one of the module procedures for .eq. is called equal, this causes
+  !       issues with ifort 16 due a bug (because lib_version also defines
+  !       equal). Therefore, we call the functions equal_grid_cell and
+  !       equall_wall_id instead.
+
   public :: operator(.eq.)
   interface operator(.eq.)
-     module procedure equal
-     module procedure equal_wall
+     module procedure equal_grid_cell
+     module procedure equal_wall_id
   end interface operator(.eq.)
 
   public :: new_grid_cell
@@ -29,17 +34,17 @@ module type_grid_cell
 
 contains
 
-  logical function equal_wall(a,b)
+  logical function equal_wall_id(a,b)
     implicit none
     type(wall_id), intent(in) :: a,b
-    equal_wall = a%w1 == b%w1 .and. a%w2 == b%w2 .and. a%w3 == b%w3
-  end function equal_wall
+    equal_wall_id = a%w1 == b%w1 .and. a%w2 == b%w2 .and. a%w3 == b%w3
+  end function equal_wall_id
 
-  logical function equal(a,b)
+  logical function equal_grid_cell(a,b)
     implicit none
     type(grid_cell), intent(in) :: a,b
-    equal = a%ic == b%ic
-  end function equal
+    equal_grid_cell = a%ic == b%ic
+  end function equal_grid_cell
 
   type(grid_cell) function new_grid_cell(ic, geo) result(cell)
     implicit none


### PR DESCRIPTION
...  which appears to occur because both the type_grid_cell and lib_version modules define a function called equal (normally this shouldn't be a problem because those functions should be private).