### PR TITLE
Import six standalone and gfortran9(?) bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ htmlcov
 *.rtin
 *.rtout
 build_cmake
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ htmlcov
 *.rtout
 build_cmake
 .vscode
+dist
+Hyperion.egg-info
+

--- a/hyperion/conf/conf_files.py
+++ b/hyperion/conf/conf_files.py
@@ -3,10 +3,7 @@ from __future__ import print_function, division
 import warnings
 import numpy as np
 from astropy import log as logger
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from ..util.functions import FreezableClass, bool2str, str2bool, is_numpy_array
 from ..filter import Filter

--- a/hyperion/conf/conf_files.py
+++ b/hyperion/conf/conf_files.py
@@ -3,7 +3,10 @@ from __future__ import print_function, division
 import warnings
 import numpy as np
 from astropy import log as logger
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from ..util.functions import FreezableClass, bool2str, str2bool, is_numpy_array
 from ..filter import Filter

--- a/hyperion/densities/alpha_disk.py
+++ b/hyperion/densities/alpha_disk.py
@@ -2,7 +2,10 @@ from __future__ import print_function, division
 
 import numpy as np
 from astropy import log as logger
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from ..dust import SphericalDust
 from ..util.constants import pi, G

--- a/hyperion/densities/alpha_disk.py
+++ b/hyperion/densities/alpha_disk.py
@@ -2,10 +2,7 @@ from __future__ import print_function, division
 
 import numpy as np
 from astropy import log as logger
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from ..dust import SphericalDust
 from ..util.constants import pi, G

--- a/hyperion/densities/ambient_medium.py
+++ b/hyperion/densities/ambient_medium.py
@@ -1,10 +1,7 @@
 from __future__ import print_function, division
 
 import numpy as np
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from ..dust import SphericalDust
 from ..grid import SphericalPolarGrid

--- a/hyperion/densities/ambient_medium.py
+++ b/hyperion/densities/ambient_medium.py
@@ -1,7 +1,10 @@
 from __future__ import print_function, division
 
 import numpy as np
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from ..dust import SphericalDust
 from ..grid import SphericalPolarGrid

--- a/hyperion/densities/bipolar_cavity.py
+++ b/hyperion/densities/bipolar_cavity.py
@@ -2,10 +2,7 @@ from __future__ import print_function, division
 
 import numpy as np
 from astropy import log as logger
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from ..util.functions import FreezableClass
 from ..dust import SphericalDust

--- a/hyperion/densities/bipolar_cavity.py
+++ b/hyperion/densities/bipolar_cavity.py
@@ -2,7 +2,10 @@ from __future__ import print_function, division
 
 import numpy as np
 from astropy import log as logger
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from ..util.functions import FreezableClass
 from ..dust import SphericalDust

--- a/hyperion/densities/flared_disk.py
+++ b/hyperion/densities/flared_disk.py
@@ -2,7 +2,10 @@ from __future__ import print_function, division
 
 import numpy as np
 from astropy import log as logger
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from ..dust import SphericalDust
 from ..util.constants import pi

--- a/hyperion/densities/flared_disk.py
+++ b/hyperion/densities/flared_disk.py
@@ -2,10 +2,7 @@ from __future__ import print_function, division
 
 import numpy as np
 from astropy import log as logger
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from ..dust import SphericalDust
 from ..util.constants import pi

--- a/hyperion/densities/power_law_envelope.py
+++ b/hyperion/densities/power_law_envelope.py
@@ -2,10 +2,7 @@ from __future__ import print_function, division
 
 import numpy as np
 from astropy import log as logger
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from ..dust import SphericalDust
 from ..grid import SphericalPolarGrid, CylindricalPolarGrid

--- a/hyperion/densities/power_law_envelope.py
+++ b/hyperion/densities/power_law_envelope.py
@@ -2,7 +2,10 @@ from __future__ import print_function, division
 
 import numpy as np
 from astropy import log as logger
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from ..dust import SphericalDust
 from ..grid import SphericalPolarGrid, CylindricalPolarGrid

--- a/hyperion/densities/ulrich_envelope.py
+++ b/hyperion/densities/ulrich_envelope.py
@@ -2,10 +2,7 @@ from __future__ import print_function, division
 
 import numpy as np
 from astropy import log as logger
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from ..dust import SphericalDust
 from ..grid import SphericalPolarGrid, CylindricalPolarGrid

--- a/hyperion/densities/ulrich_envelope.py
+++ b/hyperion/densities/ulrich_envelope.py
@@ -2,7 +2,10 @@ from __future__ import print_function, division
 
 import numpy as np
 from astropy import log as logger
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from ..dust import SphericalDust
 from ..grid import SphericalPolarGrid, CylindricalPolarGrid

--- a/hyperion/dust/dust_type.py
+++ b/hyperion/dust/dust_type.py
@@ -17,10 +17,7 @@ import hashlib
 import h5py
 import numpy as np
 from astropy import log as logger
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from ..version import __version__
 

--- a/hyperion/dust/dust_type.py
+++ b/hyperion/dust/dust_type.py
@@ -17,7 +17,10 @@ import hashlib
 import h5py
 import numpy as np
 from astropy import log as logger
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from ..version import __version__
 

--- a/hyperion/filter/filter.py
+++ b/hyperion/filter/filter.py
@@ -2,7 +2,10 @@ from __future__ import print_function, division
 
 import numpy as np
 
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 from astropy import units as u
 
 from ..util.integrate import integrate

--- a/hyperion/filter/filter.py
+++ b/hyperion/filter/filter.py
@@ -2,10 +2,7 @@ from __future__ import print_function, division
 
 import numpy as np
 
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 from astropy import units as u
 
 from ..util.integrate import integrate

--- a/hyperion/grid/tests/test_io.py
+++ b/hyperion/grid/tests/test_io.py
@@ -3,7 +3,10 @@ from copy import deepcopy
 import h5py
 import numpy as np
 import pytest
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from ...util.functions import random_id
 from .. import (CartesianGrid,

--- a/hyperion/grid/tests/test_io.py
+++ b/hyperion/grid/tests/test_io.py
@@ -3,10 +3,7 @@ from copy import deepcopy
 import h5py
 import numpy as np
 import pytest
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from ...util.functions import random_id
 from .. import (CartesianGrid,

--- a/hyperion/grid/tests/test_views.py
+++ b/hyperion/grid/tests/test_views.py
@@ -2,7 +2,10 @@ from copy import deepcopy
 
 import numpy as np
 import pytest
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from hyperion.grid import CartesianGrid, CylindricalPolarGrid, SphericalPolarGrid, AMRGrid, OctreeGrid
 

--- a/hyperion/grid/tests/test_views.py
+++ b/hyperion/grid/tests/test_views.py
@@ -2,10 +2,7 @@ from copy import deepcopy
 
 import numpy as np
 import pytest
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from hyperion.grid import CartesianGrid, CylindricalPolarGrid, SphericalPolarGrid, AMRGrid, OctreeGrid
 

--- a/hyperion/grid/yt3_wrappers.py
+++ b/hyperion/grid/yt3_wrappers.py
@@ -1,7 +1,10 @@
 from __future__ import print_function, division
 
 import numpy as np
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 from astropy import log as logger
 
 

--- a/hyperion/grid/yt3_wrappers.py
+++ b/hyperion/grid/yt3_wrappers.py
@@ -1,10 +1,7 @@
 from __future__ import print_function, division
 
 import numpy as np
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 from astropy import log as logger
 
 

--- a/hyperion/importers/orion.py
+++ b/hyperion/importers/orion.py
@@ -3,10 +3,7 @@ from __future__ import print_function, division
 import numpy as np
 
 from astropy import log as logger
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from ..grid.amr_grid import Grid, Level, AMRGrid
 

--- a/hyperion/importers/orion.py
+++ b/hyperion/importers/orion.py
@@ -3,7 +3,10 @@ from __future__ import print_function, division
 import numpy as np
 
 from astropy import log as logger
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from ..grid.amr_grid import Grid, Level, AMRGrid
 

--- a/hyperion/model/image.py
+++ b/hyperion/model/image.py
@@ -1,6 +1,9 @@
 import numpy as np
 
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from ..util.functions import FreezableClass, is_numpy_array
 from ..util.constants import c

--- a/hyperion/model/image.py
+++ b/hyperion/model/image.py
@@ -1,9 +1,6 @@
 import numpy as np
 
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from ..util.functions import FreezableClass, is_numpy_array
 from ..util.constants import c

--- a/hyperion/model/model.py
+++ b/hyperion/model/model.py
@@ -9,7 +9,10 @@ import h5py
 import numpy as np
 
 from astropy import log as logger
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from ..version import __version__
 from ..util.functions import delete_file

--- a/hyperion/model/model.py
+++ b/hyperion/model/model.py
@@ -9,10 +9,7 @@ import h5py
 import numpy as np
 
 from astropy import log as logger
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from ..version import __version__
 from ..util.functions import delete_file

--- a/hyperion/model/model_output.py
+++ b/hyperion/model/model_output.py
@@ -5,7 +5,10 @@ import warnings
 
 import numpy as np
 from astropy import log as logger
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from ..util.constants import c, pi
 from ..util.functions import FreezableClass

--- a/hyperion/model/model_output.py
+++ b/hyperion/model/model_output.py
@@ -5,10 +5,7 @@ import warnings
 
 import numpy as np
 from astropy import log as logger
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from ..util.constants import c, pi
 from ..util.functions import FreezableClass

--- a/hyperion/model/sed.py
+++ b/hyperion/model/sed.py
@@ -1,6 +1,9 @@
 import numpy as np
 
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from ..util.functions import FreezableClass
 from ..util.constants import c

--- a/hyperion/model/sed.py
+++ b/hyperion/model/sed.py
@@ -1,9 +1,6 @@
 import numpy as np
 
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from ..util.functions import FreezableClass
 from ..util.constants import c

--- a/hyperion/model/tests/test_bit_level.py
+++ b/hyperion/model/tests/test_bit_level.py
@@ -15,10 +15,7 @@ except:
     from astropy.tests.helper import pytest
 import numpy as np
 
-try:
-    from six import StringIO
-except:
-    from astropy.extern.six import StringIO
+from six import StringIO
 from .test_helpers import random_id, assert_identical_results
 from .. import Model, AnalyticalYSOModel
 from ...util.constants import pc, lsun, c, au, msun, pi, sigma, rsun

--- a/hyperion/model/tests/test_bit_level.py
+++ b/hyperion/model/tests/test_bit_level.py
@@ -9,10 +9,16 @@ import os
 import shutil
 import itertools
 
-import pytest
+try:
+    import pytest
+except:
+    from astropy.tests.helper import pytest
 import numpy as np
 
-from astropy.extern.six import StringIO
+try:
+    from six import StringIO
+except:
+    from astropy.extern.six import StringIO
 from .test_helpers import random_id, assert_identical_results
 from .. import Model, AnalyticalYSOModel
 from ...util.constants import pc, lsun, c, au, msun, pi, sigma, rsun
@@ -24,7 +30,6 @@ GRID_TYPES = ['car', 'cyl', 'sph', 'amr', 'oct']
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 
 bit_level = pytest.mark.skipif(str(not pytest.config.getoption('enable_bit_level_tests')))
-
 
 @pytest.fixture(scope="module")
 def generate(request):

--- a/hyperion/model/tests/test_sed.py
+++ b/hyperion/model/tests/test_sed.py
@@ -8,7 +8,10 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal_nulp
 
 import pytest
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from .. import Model
 from ..sed import SED

--- a/hyperion/model/tests/test_sed.py
+++ b/hyperion/model/tests/test_sed.py
@@ -8,10 +8,7 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal_nulp
 
 import pytest
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from .. import Model
 from ..sed import SED

--- a/hyperion/util/tests/test_integrate.py
+++ b/hyperion/util/tests/test_integrate.py
@@ -6,7 +6,10 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal_nulp
 
 import pytest
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 from ..integrate import *
 

--- a/hyperion/util/tests/test_integrate.py
+++ b/hyperion/util/tests/test_integrate.py
@@ -6,10 +6,7 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal_nulp
 
 import pytest
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 from ..integrate import *
 

--- a/hyperion/util/validator.py
+++ b/hyperion/util/validator.py
@@ -1,10 +1,7 @@
 import numpy as np
 
 from astropy import units as u
-try:
-    import six
-except:
-    from astropy.extern import six
+import six
 
 
 def validate_physical_type(name, value, physical_type):

--- a/hyperion/util/validator.py
+++ b/hyperion/util/validator.py
@@ -1,7 +1,10 @@
 import numpy as np
 
 from astropy import units as u
-from astropy.extern import six
+try:
+    import six
+except:
+    from astropy.extern import six
 
 
 def validate_physical_type(name, value, physical_type):

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,6 @@ setup(name='Hyperion',
       cmdclass=cmdclass,
       ext_modules=ext_modules,
       setup_requires=['numpy>=1.11'],
-      install_requires=['numpy>=1.11', 'matplotlib>=1.5', 'astropy>=1.2', 'h5py>=2.4', 'yt>=3.2'],
+      install_requires=['numpy>=1.11', 'matplotlib>=1.5', 'astropy>=1.2', 'h5py>=2.4', 'yt>=3.2', 'six'],
       extras_require={'test': ['pytest'],
                       'docs': ['sphinx', 'numpydoc']})

--- a/src/dust/dust_interact.f90
+++ b/src/dust/dust_interact.f90
@@ -28,7 +28,10 @@ contains
     real(dp) :: xi,albedo
     real(dp) :: energy_scaling
     logical,optional :: force_scatter
+    logical :: force_scatter_val = .false.
 
+    if(present(force_scatter)) force_scatter_val = force_scatter
+    
     ! given the density and energy of each dust type, process a photon
     ! this means finding out whether to scatter or aborb the photon, and to do
     ! whatever needs doing
@@ -43,7 +46,7 @@ contains
     p%s_prev = p%s
 
     ! Decide whether to absorb or scatter
-    if(present(force_scatter) .and. force_scatter) then
+    if(force_scatter_val) then
       xi = 0._dp
     else
       call random(xi)
@@ -69,7 +72,7 @@ contains
 
     call angle3d_to_vector3d(p%a,p%v)
 
-    if(present(force_scatter) .and. force_scatter) then
+    if(force_scatter_val) then
       p%energy = p%energy * albedo
     end if
 

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -453,7 +453,7 @@ contains
 
     write(*,*)
     write(*,'("     -> Percentile: ",F7.2)') convergence_percentile
-    write(*,'("     -> Value @ Percentile: ",F10.2)') value
+    write(*,'("     -> Value @ Percentile: ",E10.3)') value
     if(value_prev < huge(1._dp)) then
        if(value == 0._dp) then
           write(*,'("     -> Exact convergence")')


### PR DESCRIPTION
astropy doesn't package six anymore, so I replaced all of its imports with a try/except with an import from a standalone module. There was a similar issue with pytest. I didn't include six in the `install_requires` to be backwards compatible with previous installs. This addresses #219.

I fixed a segfault (I'm using gfortran v9.2.1) that came from an optional argument not having a default value. I also changed the write format of the percentile value during the iterations because my runs had very large values.
```
Program received signal SIGSEGV: Segmentation fault - invalid memory reference.

Backtrace for this error:
#0  0x7f9290439cb1 in ???
#1  0x7f9290438e75 in ???
#2  0x7f929011e46f in ???
#3  0x555f7c2a6258 in __dust_interact_MOD_interact
        at src/dust/dust_interact.f90:46
#4  0x555f7c2d91e4 in __iteration_lucy_MOD_do_lucy
        at src/main/iter_lucy.f90:201
#5  0x555f7c2dc494 in MAIN__
        at src/main/main.f90:183
#6  0x555f7c2dd014 in main
        at src/main/main.f90:3
Segmentation fault
```