### PR TITLE
Clarify columns included in the mean_opacities file

### DIFF
--- a/docs/advanced/dust_file.rst
+++ b/docs/advanced/dust_file.rst
@@ -86,7 +86,12 @@ The temperatures specified should range from 0.1K (or less) to a
 temperature safely above the maximum temperature expected for the dust in
 the system.
 
-``emissivities``
+The resulting hdf5 file will end up with [8 columns](https://github.com/hyperion-rt/hyperion/blob/2159b39f5cafaeb653f2541502eef194a78102d6/hyperion/dust/mean_opacities.py#L15-L27):
+``temperature``, ``specific_energy``, ``chi_planck``, ``kappa_planck``, ``chi_inv_planck``,
+``kappa_inv_planck``, ``chi_rosseland``, ``kappa_rosseland``.
+The ``_inv`` columns are the inverse (reciprocal) of their counterparts.
+
+
 ----------------
 
 This dataset should consist of a table specifying the emissivities. The


### PR DESCRIPTION
@richardson-t found that there are extra columns in the hdf5 files - they weren't described, but can be reconstructed from the source code.