### PR TITLE
Compute and save the ISRF in every cell

### DIFF
--- a/docs/setup/setup_conf.rst
+++ b/docs/setup/setup_conf.rst
@@ -223,12 +223,10 @@ Photons are binned to the nearest frequency in log space. Summed over frequency,
 ``specific_energy_nu`` recovers the total ``specific_energy``. This option is
 disabled by default and works for all grid types, including AMR.
 
-``specific_energy_nu`` is not currently returned by ``get_quantities`` and
-should be read directly from the output file, e.g.::
+``specific_energy_nu`` can be retrieved like other grid quantities, as an array
+with an extra leading frequency axis::
 
-    import h5py
-    with h5py.File('output.rtout', 'r') as f:
-        senu = f['iteration_00005/specific_energy_nu'][()]
+    senu = m.get_quantities()['specific_energy_nu']
 
 Advanced parameters
 -------------------

--- a/docs/setup/setup_conf.rst
+++ b/docs/setup/setup_conf.rst
@@ -201,7 +201,7 @@ Frequency-resolved specific energy
 In addition to the total specific energy absorbed in each cell
 (``output_specific_energy``), Hyperion can save the specific energy absorbed as
 a function of frequency. This is controlled in the same way as the other output
-quantities -- there is no separate switch to enable it::
+quantities::
 
     m.conf.output.output_specific_energy_nu = 'all'    # every iteration
                                               # 'last'  -> only final iteration

--- a/docs/setup/setup_conf.rst
+++ b/docs/setup/setup_conf.rst
@@ -212,7 +212,8 @@ When it is not ``'none'``, two extra arrays are written out:
 * ``specific_energy_nu`` -- the specific energy absorbed in each cell as a
   function of frequency, in erg/s/g.
 * ``specific_energy_nu_frequencies`` -- the frequencies (in Hz) corresponding to
-  the leading axis of ``specific_energy_nu``.
+  the leading axis of ``specific_energy_nu``. These are bin centers, not edges,
+  so this array has exactly the same length as that axis (one entry per bin).
 
 This is the *absorbed* (deposited) energy spectrum, not the mean intensity: each
 contribution is weighted by the dust absorption opacity, so it is proportional
@@ -228,7 +229,8 @@ properties::
     import numpy as np
     m.set_specific_energy_nu_frequencies(np.logspace(11., 16., 100))
 
-Photons are binned to the nearest frequency in log space. This works for all
+Photons are binned to the nearest of these frequencies in log space (so the
+supplied values act as bin centers). This works for all
 grid types, including AMR and Voronoi.
 
 ``specific_energy_nu`` can be retrieved like other grid quantities, as an array

--- a/docs/setup/setup_conf.rst
+++ b/docs/setup/setup_conf.rst
@@ -233,6 +233,15 @@ Photons are binned to the nearest of these frequencies in log space (so the
 supplied values act as bin centers). This works for all
 grid types, including AMR and Voronoi.
 
+.. warning:: The binning has no outer edges: the first and last bins collect
+             *all* photons below and above the outermost bin centers
+             respectively, however far away in frequency. This keeps the spectrum
+             energy-conserving (no photons are dropped), but it means a grid that
+             does not span the full frequency range will pile up out-of-range
+             flux in its end bins. When supplying a custom grid, make sure it
+             brackets the full range of frequencies present in the simulation
+             (the default dust-based grid already does this).
+
 ``specific_energy_spectrum`` can be retrieved like other grid quantities, as an array
 with an extra leading frequency axis::
 

--- a/docs/setup/setup_conf.rst
+++ b/docs/setup/setup_conf.rst
@@ -212,10 +212,16 @@ When enabled, two extra arrays are written out following the same
 * ``ISRF_frequency_bins`` -- the frequencies (in Hz) corresponding to the last
   axis of ``specific_energy_nu``.
 
-The frequency grid is taken from the first dust type, so all dust types should
-share the same frequency grid. Summed over frequency, ``specific_energy_nu``
-recovers the total ``specific_energy``. This option is disabled by default and
-works for all grid types, including AMR.
+By default, the ISRF is binned onto the frequency grid of the first dust type.
+You can instead specify your own frequency grid (in Hz), independent of the dust
+properties, by passing the ``frequencies`` argument::
+
+    import numpy as np
+    m.compute_isrf(True, frequencies=np.logspace(11., 16., 100))
+
+Photons are binned to the nearest frequency in log space. Summed over frequency,
+``specific_energy_nu`` recovers the total ``specific_energy``. This option is
+disabled by default and works for all grid types, including AMR.
 
 ``specific_energy_nu`` is not currently returned by ``get_quantities`` and
 should be read directly from the output file, e.g.::

--- a/docs/setup/setup_conf.rst
+++ b/docs/setup/setup_conf.rst
@@ -195,6 +195,35 @@ only after last iteration), or ``none`` (do not output). The default is to
 output only the last iteration of ``specific_energy``. To find out how to view
 these values, see :doc:`../postprocessing/postprocessing`
 
+Interstellar radiation field
+----------------------------
+
+By default, Hyperion saves the total specific energy absorbed in each cell. If
+you also want the frequency-resolved specific energy absorbed (the interstellar
+radiation field, ISRF), you can enable this with::
+
+    m.compute_isrf(True)
+
+When enabled, two extra arrays are written out following the same
+``output_specific_energy`` setting described above:
+
+* ``specific_energy_nu`` -- the specific energy absorbed in each cell as a
+  function of frequency, in erg/s/g.
+* ``ISRF_frequency_bins`` -- the frequencies (in Hz) corresponding to the last
+  axis of ``specific_energy_nu``.
+
+The frequency grid is taken from the first dust type, so all dust types should
+share the same frequency grid. Summed over frequency, ``specific_energy_nu``
+recovers the total ``specific_energy``. This option is disabled by default and
+works for all grid types, including AMR.
+
+``specific_energy_nu`` is not currently returned by ``get_quantities`` and
+should be read directly from the output file, e.g.::
+
+    import h5py
+    with h5py.File('output.rtout', 'r') as f:
+        senu = f['iteration_00005/specific_energy_nu'][()]
+
 Advanced parameters
 -------------------
 

--- a/docs/setup/setup_conf.rst
+++ b/docs/setup/setup_conf.rst
@@ -203,23 +203,23 @@ In addition to the total specific energy absorbed in each cell
 a function of frequency. This is controlled in the same way as the other output
 quantities::
 
-    m.conf.output.output_specific_energy_nu = 'all'    # every iteration
+    m.conf.output.output_specific_energy_spectrum = 'all'    # every iteration
                                               # 'last'  -> only final iteration
                                               # 'none'  -> not computed or saved (default)
 
 When it is not ``'none'``, two extra arrays are written out:
 
-* ``specific_energy_nu`` -- the specific energy absorbed in each cell as a
+* ``specific_energy_spectrum`` -- the specific energy absorbed in each cell as a
   function of frequency, in erg/s/g.
-* ``specific_energy_nu_frequencies`` -- the frequencies (in Hz) corresponding to
-  the leading axis of ``specific_energy_nu``. These are bin centers, not edges,
+* ``specific_energy_spectrum_frequencies`` -- the frequencies (in Hz) corresponding to
+  the leading axis of ``specific_energy_spectrum``. These are bin centers, not edges,
   so this array has exactly the same length as that axis (one entry per bin).
 
 This is the *absorbed* (deposited) energy spectrum, not the mean intensity: each
 contribution is weighted by the dust absorption opacity, so it is proportional
 to :math:`\kappa_\nu J_\nu`. To recover the mean intensity :math:`J_\nu` (the
 radiation field), divide by the dust absorption opacity at each frequency.
-Summed over frequency, ``specific_energy_nu`` recovers the total
+Summed over frequency, ``specific_energy_spectrum`` recovers the total
 ``specific_energy``.
 
 By default the binning uses the frequency grid of the first dust type. You can
@@ -227,16 +227,16 @@ instead provide your own frequency grid (in Hz), independent of the dust
 properties::
 
     import numpy as np
-    m.set_specific_energy_nu_frequencies(np.logspace(11., 16., 100))
+    m.set_specific_energy_spectrum_frequencies(np.logspace(11., 16., 100))
 
 Photons are binned to the nearest of these frequencies in log space (so the
 supplied values act as bin centers). This works for all
 grid types, including AMR and Voronoi.
 
-``specific_energy_nu`` can be retrieved like other grid quantities, as an array
+``specific_energy_spectrum`` can be retrieved like other grid quantities, as an array
 with an extra leading frequency axis::
 
-    senu = m.get_quantities()['specific_energy_nu']
+    senu = m.get_quantities()['specific_energy_spectrum']
 
 Advanced parameters
 -------------------

--- a/docs/setup/setup_conf.rst
+++ b/docs/setup/setup_conf.rst
@@ -195,33 +195,41 @@ only after last iteration), or ``none`` (do not output). The default is to
 output only the last iteration of ``specific_energy``. To find out how to view
 these values, see :doc:`../postprocessing/postprocessing`
 
-Interstellar radiation field
-----------------------------
+Frequency-resolved specific energy
+----------------------------------
 
-By default, Hyperion saves the total specific energy absorbed in each cell. If
-you also want the frequency-resolved specific energy absorbed (the interstellar
-radiation field, ISRF), you can enable this with::
+In addition to the total specific energy absorbed in each cell
+(``output_specific_energy``), Hyperion can save the specific energy absorbed as
+a function of frequency. This is controlled in the same way as the other output
+quantities -- there is no separate switch to enable it::
 
-    m.compute_isrf(True)
+    m.conf.output.output_specific_energy_nu = 'all'    # every iteration
+                                              # 'last'  -> only final iteration
+                                              # 'none'  -> not computed or saved (default)
 
-When enabled, two extra arrays are written out following the same
-``output_specific_energy`` setting described above:
+When it is not ``'none'``, two extra arrays are written out:
 
 * ``specific_energy_nu`` -- the specific energy absorbed in each cell as a
   function of frequency, in erg/s/g.
-* ``ISRF_frequency_bins`` -- the frequencies (in Hz) corresponding to the last
-  axis of ``specific_energy_nu``.
+* ``specific_energy_nu_frequencies`` -- the frequencies (in Hz) corresponding to
+  the leading axis of ``specific_energy_nu``.
 
-By default, the ISRF is binned onto the frequency grid of the first dust type.
-You can instead specify your own frequency grid (in Hz), independent of the dust
-properties, by passing the ``frequencies`` argument::
+This is the *absorbed* (deposited) energy spectrum, not the mean intensity: each
+contribution is weighted by the dust absorption opacity, so it is proportional
+to :math:`\kappa_\nu J_\nu`. To recover the mean intensity :math:`J_\nu` (the
+radiation field), divide by the dust absorption opacity at each frequency.
+Summed over frequency, ``specific_energy_nu`` recovers the total
+``specific_energy``.
+
+By default the binning uses the frequency grid of the first dust type. You can
+instead provide your own frequency grid (in Hz), independent of the dust
+properties::
 
     import numpy as np
-    m.compute_isrf(True, frequencies=np.logspace(11., 16., 100))
+    m.set_specific_energy_nu_frequencies(np.logspace(11., 16., 100))
 
-Photons are binned to the nearest frequency in log space. Summed over frequency,
-``specific_energy_nu`` recovers the total ``specific_energy``. This option is
-disabled by default and works for all grid types, including AMR.
+Photons are binned to the nearest frequency in log space. This works for all
+grid types, including AMR and Voronoi.
 
 ``specific_energy_nu`` can be retrieved like other grid quantities, as an array
 with an extra leading frequency axis::

--- a/hyperion/conf/conf_files.py
+++ b/hyperion/conf/conf_files.py
@@ -18,6 +18,7 @@ class OutputConf(FreezableClass):
         self.output_density = 'none'
         self.output_density_diff = 'none'
         self.output_specific_energy = 'last'
+        self.output_specific_energy_nu = 'last'
         self.output_n_photons = 'none'
         self._freeze()
 
@@ -27,6 +28,7 @@ class OutputConf(FreezableClass):
         self.output_density = group.attrs['output_density'].decode('utf-8')
         self.output_density_diff = group.attrs['output_density_diff'].decode('utf-8')
         self.output_specific_energy = group.attrs['output_specific_energy'].decode('utf-8')
+        self.output_specific_energy_nu = group.attrs['output_specific_energy_nu'].decode('utf-8')
         self.output_n_photons = group.attrs['output_n_photons'].decode('utf-8')
         return self
 
@@ -34,6 +36,7 @@ class OutputConf(FreezableClass):
         group.attrs['output_density'] = np.string_(self.output_density.encode('utf-8'))
         group.attrs['output_density_diff'] = np.string_(self.output_density_diff.encode('utf-8'))
         group.attrs['output_specific_energy'] = np.string_(self.output_specific_energy.encode('utf-8'))
+        group.attrs['output_specific_energy_nu'] = np.string_(self.output_specific_energ_nu.encode('utf-8'))
         group.attrs['output_n_photons'] = np.string_(self.output_n_photons.encode('utf-8'))
 
 

--- a/hyperion/conf/conf_files.py
+++ b/hyperion/conf/conf_files.py
@@ -55,7 +55,6 @@ class RunConf(object):
         self.set_max_reabsorptions(1000000)
         self.set_pda(False)
         self.set_mrw(False)
-        #DN CRAZY ADDITION
         self.compute_isrf(False)
 
         self.set_convergence(False)
@@ -403,8 +402,6 @@ class RunConf(object):
     def _write_isrf(self,group):
         group.attrs['isrf'] = bool2str(self.isrf)
 
-
-    #DN CRAZY ADDITIONS
     def compute_isrf(self,isrf):
 
         '''

--- a/hyperion/conf/conf_files.py
+++ b/hyperion/conf/conf_files.py
@@ -36,7 +36,7 @@ class OutputConf(FreezableClass):
         group.attrs['output_density'] = np.string_(self.output_density.encode('utf-8'))
         group.attrs['output_density_diff'] = np.string_(self.output_density_diff.encode('utf-8'))
         group.attrs['output_specific_energy'] = np.string_(self.output_specific_energy.encode('utf-8'))
-        group.attrs['output_specific_energy_nu'] = np.string_(self.output_specific_energ_nu.encode('utf-8'))
+        group.attrs['output_specific_energy_nu'] = np.string_(self.output_specific_energy_nu.encode('utf-8'))
         group.attrs['output_n_photons'] = np.string_(self.output_n_photons.encode('utf-8'))
 
 

--- a/hyperion/conf/conf_files.py
+++ b/hyperion/conf/conf_files.py
@@ -55,6 +55,9 @@ class RunConf(object):
         self.set_max_reabsorptions(1000000)
         self.set_pda(False)
         self.set_mrw(False)
+        #DN CRAZY ADDITION
+        self.compute_isrf(False)
+
         self.set_convergence(False)
         self.set_kill_on_absorb(False)
         self.set_kill_on_scatter(False)
@@ -394,6 +397,27 @@ class RunConf(object):
     def _write_pda(self, group):
         group.attrs['pda'] = bool2str(self.pda)
 
+    def _read_isrf(self,group):
+        self.isrf = str2bool(group.attrs['isrf'])
+        
+    def _write_isrf(self,group):
+        group.attrs['isrf'] = bool2str(self.isrf)
+
+
+    #DN CRAZY ADDITIONS
+    def compute_isrf(self,isrf):
+
+        '''
+
+        Set whether or not to compute and save the ISRF in each cell
+
+        If enabled, the ISRF is computed in every cell at the
+        frequencies of the dust opacity tables.
+
+        '''
+        self.isrf = isrf
+
+
     def set_mrw(self, mrw, gamma=1.0, inter_max=1000, warn=True):
         '''
         Set whether to use the Modified Random Walk (MRW) approximation
@@ -722,6 +746,7 @@ class RunConf(object):
         self._read_max_reabsorptions(group)
         self._read_pda(group)
         self._read_mrw(group)
+        self._reada_isrf(group)
         self._read_convergence(group)
         self._read_kill_on_absorb(group)
         self._read_kill_on_scatter(group)
@@ -750,6 +775,7 @@ class RunConf(object):
         self._write_max_reabsorptions(group)
         self._write_pda(group)
         self._write_mrw(group)
+        self._write_isrf(group)
         self._write_convergence(group)
         self._write_kill_on_absorb(group)
         self._write_kill_on_scatter(group)

--- a/hyperion/conf/conf_files.py
+++ b/hyperion/conf/conf_files.py
@@ -396,13 +396,21 @@ class RunConf(object):
     def _write_pda(self, group):
         group.attrs['pda'] = bool2str(self.pda)
 
-    def _read_isrf(self,group):
+    def _read_isrf(self, group):
         self.isrf = str2bool(group.attrs['isrf'])
-        
-    def _write_isrf(self,group):
-        group.attrs['isrf'] = bool2str(self.isrf)
+        if 'isrf_frequencies' in group:
+            self.isrf_frequencies = np.array(group['isrf_frequencies']['nu'])
+        else:
+            self.isrf_frequencies = None
 
-    def compute_isrf(self, isrf):
+    def _write_isrf(self, group):
+        group.attrs['isrf'] = bool2str(self.isrf)
+        if self.isrf and self.isrf_frequencies is not None:
+            group.create_dataset('isrf_frequencies',
+                                 data=np.array(list(zip(self.isrf_frequencies)),
+                                               dtype=[('nu', float)]))
+
+    def compute_isrf(self, isrf, frequencies=None):
 
         '''
         Set whether to compute and save the interstellar radiation field (ISRF)
@@ -411,17 +419,29 @@ class RunConf(object):
         If enabled, the specific energy absorbed is also accumulated as a
         function of frequency and saved as the ``specific_energy_nu`` quantity
         (in erg/s/g), alongside the ``ISRF_frequency_bins`` array giving the
-        corresponding frequencies (in Hz). The frequency grid is taken from the
-        first dust type, so all dust types should share the same frequency grid.
-        These arrays are written following the ``output_specific_energy``
-        setting. This is disabled by default.
+        corresponding frequencies (in Hz). Photons are binned to the nearest
+        frequency in log space. These arrays are written following the
+        ``output_specific_energy`` setting. This is disabled by default.
 
         Parameters
         ----------
         isrf : bool
             Whether to compute and save the ISRF in each cell.
+        frequencies : iterable of float, optional
+            The frequencies (in Hz) onto which to bin the ISRF. If not
+            specified, the frequency grid of the first dust type is used. Only
+            used when ``isrf`` is `True`.
         '''
         self.isrf = isrf
+        if frequencies is None:
+            self.isrf_frequencies = None
+        else:
+            frequencies = np.asarray(frequencies, dtype=float)
+            if frequencies.ndim != 1 or frequencies.size < 1:
+                raise ValueError("frequencies should be a 1-d array of at least one value")
+            if np.any(frequencies <= 0.):
+                raise ValueError("frequencies should be positive (in Hz)")
+            self.isrf_frequencies = np.sort(frequencies)
 
 
     def set_mrw(self, mrw, gamma=1.0, inter_max=1000, warn=True):

--- a/hyperion/conf/conf_files.py
+++ b/hyperion/conf/conf_files.py
@@ -743,7 +743,7 @@ class RunConf(object):
         self._read_max_reabsorptions(group)
         self._read_pda(group)
         self._read_mrw(group)
-        self._reada_isrf(group)
+        self._read_isrf(group)
         self._read_convergence(group)
         self._read_kill_on_absorb(group)
         self._read_kill_on_scatter(group)

--- a/hyperion/conf/conf_files.py
+++ b/hyperion/conf/conf_files.py
@@ -420,7 +420,8 @@ class RunConf(object):
         This is only relevant if ``conf.output.output_specific_energy_nu`` is set
         to ``'all'`` or ``'last'``. If this method is not called, the frequency
         grid of the first dust type is used. Photons are binned to the nearest
-        frequency in log space.
+        frequency in log space, so the supplied values are bin centers (not
+        edges) and ``specific_energy_nu`` has one entry per supplied frequency.
 
         Parameters
         ----------

--- a/hyperion/conf/conf_files.py
+++ b/hyperion/conf/conf_files.py
@@ -18,7 +18,7 @@ class OutputConf(FreezableClass):
         self.output_density = 'none'
         self.output_density_diff = 'none'
         self.output_specific_energy = 'last'
-        self.output_specific_energy_nu = 'none'
+        self.output_specific_energy_spectrum = 'none'
         self.output_n_photons = 'none'
         self._freeze()
 
@@ -28,10 +28,10 @@ class OutputConf(FreezableClass):
         self.output_density = group.attrs['output_density'].decode('utf-8')
         self.output_density_diff = group.attrs['output_density_diff'].decode('utf-8')
         self.output_specific_energy = group.attrs['output_specific_energy'].decode('utf-8')
-        if 'output_specific_energy_nu' in group.attrs:
-            self.output_specific_energy_nu = group.attrs['output_specific_energy_nu'].decode('utf-8')
+        if 'output_specific_energy_spectrum' in group.attrs:
+            self.output_specific_energy_spectrum = group.attrs['output_specific_energy_spectrum'].decode('utf-8')
         else:
-            self.output_specific_energy_nu = 'none'
+            self.output_specific_energy_spectrum = 'none'
         self.output_n_photons = group.attrs['output_n_photons'].decode('utf-8')
         return self
 
@@ -39,7 +39,7 @@ class OutputConf(FreezableClass):
         group.attrs['output_density'] = np.bytes_(self.output_density.encode('utf-8'))
         group.attrs['output_density_diff'] = np.bytes_(self.output_density_diff.encode('utf-8'))
         group.attrs['output_specific_energy'] = np.bytes_(self.output_specific_energy.encode('utf-8'))
-        group.attrs['output_specific_energy_nu'] = np.bytes_(self.output_specific_energy_nu.encode('utf-8'))
+        group.attrs['output_specific_energy_spectrum'] = np.bytes_(self.output_specific_energy_spectrum.encode('utf-8'))
         group.attrs['output_n_photons'] = np.bytes_(self.output_n_photons.encode('utf-8'))
 
 
@@ -58,7 +58,7 @@ class RunConf(object):
         self.set_max_reabsorptions(1000000)
         self.set_pda(False)
         self.set_mrw(False)
-        self.specific_energy_nu_frequencies = None
+        self.specific_energy_spectrum_frequencies = None
 
         self.set_convergence(False)
         self.set_kill_on_absorb(False)
@@ -399,41 +399,41 @@ class RunConf(object):
     def _write_pda(self, group):
         group.attrs['pda'] = bool2str(self.pda)
 
-    def _read_specific_energy_nu_frequencies(self, group):
-        if 'specific_energy_nu_frequencies' in group:
-            self.specific_energy_nu_frequencies = np.array(group['specific_energy_nu_frequencies']['nu'])
+    def _read_specific_energy_spectrum_frequencies(self, group):
+        if 'specific_energy_spectrum_frequencies' in group:
+            self.specific_energy_spectrum_frequencies = np.array(group['specific_energy_spectrum_frequencies']['nu'])
         else:
-            self.specific_energy_nu_frequencies = None
+            self.specific_energy_spectrum_frequencies = None
 
-    def _write_specific_energy_nu_frequencies(self, group):
-        if self.specific_energy_nu_frequencies is not None:
-            group.create_dataset('specific_energy_nu_frequencies',
-                                 data=np.array(list(zip(self.specific_energy_nu_frequencies)),
+    def _write_specific_energy_spectrum_frequencies(self, group):
+        if self.specific_energy_spectrum_frequencies is not None:
+            group.create_dataset('specific_energy_spectrum_frequencies',
+                                 data=np.array(list(zip(self.specific_energy_spectrum_frequencies)),
                                                dtype=[('nu', float)]))
 
-    def set_specific_energy_nu_frequencies(self, frequencies):
+    def set_specific_energy_spectrum_frequencies(self, frequencies):
 
         '''
         Set the frequency grid onto which the frequency-resolved specific energy
-        (``specific_energy_nu``) is binned.
+        (``specific_energy_spectrum``) is binned.
 
-        This is only relevant if ``conf.output.output_specific_energy_nu`` is set
+        This is only relevant if ``conf.output.output_specific_energy_spectrum`` is set
         to ``'all'`` or ``'last'``. If this method is not called, the frequency
         grid of the first dust type is used. Photons are binned to the nearest
         frequency in log space, so the supplied values are bin centers (not
-        edges) and ``specific_energy_nu`` has one entry per supplied frequency.
+        edges) and ``specific_energy_spectrum`` has one entry per supplied frequency.
 
         Parameters
         ----------
         frequencies : iterable of float
-            The frequencies (in Hz) onto which to bin ``specific_energy_nu``.
+            The frequencies (in Hz) onto which to bin ``specific_energy_spectrum``.
         '''
         frequencies = np.asarray(frequencies, dtype=float)
         if frequencies.ndim != 1 or frequencies.size < 1:
             raise ValueError("frequencies should be a 1-d array of at least one value")
         if np.any(frequencies <= 0.):
             raise ValueError("frequencies should be positive (in Hz)")
-        self.specific_energy_nu_frequencies = np.sort(frequencies)
+        self.specific_energy_spectrum_frequencies = np.sort(frequencies)
 
 
     def set_mrw(self, mrw, gamma=1.0, inter_max=1000, warn=True):
@@ -764,7 +764,7 @@ class RunConf(object):
         self._read_max_reabsorptions(group)
         self._read_pda(group)
         self._read_mrw(group)
-        self._read_specific_energy_nu_frequencies(group)
+        self._read_specific_energy_spectrum_frequencies(group)
         self._read_convergence(group)
         self._read_kill_on_absorb(group)
         self._read_kill_on_scatter(group)
@@ -793,7 +793,7 @@ class RunConf(object):
         self._write_max_reabsorptions(group)
         self._write_pda(group)
         self._write_mrw(group)
-        self._write_specific_energy_nu_frequencies(group)
+        self._write_specific_energy_spectrum_frequencies(group)
         self._write_convergence(group)
         self._write_kill_on_absorb(group)
         self._write_kill_on_scatter(group)

--- a/hyperion/conf/conf_files.py
+++ b/hyperion/conf/conf_files.py
@@ -18,6 +18,7 @@ class OutputConf(FreezableClass):
         self.output_density = 'none'
         self.output_density_diff = 'none'
         self.output_specific_energy = 'last'
+        self.output_specific_energy_nu = 'last'
         self.output_n_photons = 'none'
         self._freeze()
 
@@ -27,6 +28,7 @@ class OutputConf(FreezableClass):
         self.output_density = group.attrs['output_density'].decode('utf-8')
         self.output_density_diff = group.attrs['output_density_diff'].decode('utf-8')
         self.output_specific_energy = group.attrs['output_specific_energy'].decode('utf-8')
+        self.output_specific_energy_nu = group.attrs['output_specific_energy_nu'].decode('utf-8')
         self.output_n_photons = group.attrs['output_n_photons'].decode('utf-8')
         return self
 
@@ -34,6 +36,7 @@ class OutputConf(FreezableClass):
         group.attrs['output_density'] = np.bytes_(self.output_density.encode('utf-8'))
         group.attrs['output_density_diff'] = np.bytes_(self.output_density_diff.encode('utf-8'))
         group.attrs['output_specific_energy'] = np.bytes_(self.output_specific_energy.encode('utf-8'))
+        group.attrs['output_specific_energy_nu'] = np.bytes_(self.output_specific_energ_nu.encode('utf-8'))
         group.attrs['output_n_photons'] = np.bytes_(self.output_n_photons.encode('utf-8'))
 
 

--- a/hyperion/conf/conf_files.py
+++ b/hyperion/conf/conf_files.py
@@ -18,7 +18,7 @@ class OutputConf(FreezableClass):
         self.output_density = 'none'
         self.output_density_diff = 'none'
         self.output_specific_energy = 'last'
-        self.output_specific_energy_nu = 'last'
+        self.output_specific_energy_nu = 'none'
         self.output_n_photons = 'none'
         self._freeze()
 
@@ -28,7 +28,10 @@ class OutputConf(FreezableClass):
         self.output_density = group.attrs['output_density'].decode('utf-8')
         self.output_density_diff = group.attrs['output_density_diff'].decode('utf-8')
         self.output_specific_energy = group.attrs['output_specific_energy'].decode('utf-8')
-        self.output_specific_energy_nu = group.attrs['output_specific_energy_nu'].decode('utf-8')
+        if 'output_specific_energy_nu' in group.attrs:
+            self.output_specific_energy_nu = group.attrs['output_specific_energy_nu'].decode('utf-8')
+        else:
+            self.output_specific_energy_nu = 'none'
         self.output_n_photons = group.attrs['output_n_photons'].decode('utf-8')
         return self
 
@@ -55,7 +58,7 @@ class RunConf(object):
         self.set_max_reabsorptions(1000000)
         self.set_pda(False)
         self.set_mrw(False)
-        self.compute_isrf(False)
+        self.specific_energy_nu_frequencies = None
 
         self.set_convergence(False)
         self.set_kill_on_absorb(False)
@@ -396,52 +399,40 @@ class RunConf(object):
     def _write_pda(self, group):
         group.attrs['pda'] = bool2str(self.pda)
 
-    def _read_isrf(self, group):
-        self.isrf = str2bool(group.attrs['isrf'])
-        if 'isrf_frequencies' in group:
-            self.isrf_frequencies = np.array(group['isrf_frequencies']['nu'])
+    def _read_specific_energy_nu_frequencies(self, group):
+        if 'specific_energy_nu_frequencies' in group:
+            self.specific_energy_nu_frequencies = np.array(group['specific_energy_nu_frequencies']['nu'])
         else:
-            self.isrf_frequencies = None
+            self.specific_energy_nu_frequencies = None
 
-    def _write_isrf(self, group):
-        group.attrs['isrf'] = bool2str(self.isrf)
-        if self.isrf and self.isrf_frequencies is not None:
-            group.create_dataset('isrf_frequencies',
-                                 data=np.array(list(zip(self.isrf_frequencies)),
+    def _write_specific_energy_nu_frequencies(self, group):
+        if self.specific_energy_nu_frequencies is not None:
+            group.create_dataset('specific_energy_nu_frequencies',
+                                 data=np.array(list(zip(self.specific_energy_nu_frequencies)),
                                                dtype=[('nu', float)]))
 
-    def compute_isrf(self, isrf, frequencies=None):
+    def set_specific_energy_nu_frequencies(self, frequencies):
 
         '''
-        Set whether to compute and save the interstellar radiation field (ISRF)
-        in each cell.
+        Set the frequency grid onto which the frequency-resolved specific energy
+        (``specific_energy_nu``) is binned.
 
-        If enabled, the specific energy absorbed is also accumulated as a
-        function of frequency and saved as the ``specific_energy_nu`` quantity
-        (in erg/s/g), alongside the ``ISRF_frequency_bins`` array giving the
-        corresponding frequencies (in Hz). Photons are binned to the nearest
-        frequency in log space. These arrays are written following the
-        ``output_specific_energy`` setting. This is disabled by default.
+        This is only relevant if ``conf.output.output_specific_energy_nu`` is set
+        to ``'all'`` or ``'last'``. If this method is not called, the frequency
+        grid of the first dust type is used. Photons are binned to the nearest
+        frequency in log space.
 
         Parameters
         ----------
-        isrf : bool
-            Whether to compute and save the ISRF in each cell.
-        frequencies : iterable of float, optional
-            The frequencies (in Hz) onto which to bin the ISRF. If not
-            specified, the frequency grid of the first dust type is used. Only
-            used when ``isrf`` is `True`.
+        frequencies : iterable of float
+            The frequencies (in Hz) onto which to bin ``specific_energy_nu``.
         '''
-        self.isrf = isrf
-        if frequencies is None:
-            self.isrf_frequencies = None
-        else:
-            frequencies = np.asarray(frequencies, dtype=float)
-            if frequencies.ndim != 1 or frequencies.size < 1:
-                raise ValueError("frequencies should be a 1-d array of at least one value")
-            if np.any(frequencies <= 0.):
-                raise ValueError("frequencies should be positive (in Hz)")
-            self.isrf_frequencies = np.sort(frequencies)
+        frequencies = np.asarray(frequencies, dtype=float)
+        if frequencies.ndim != 1 or frequencies.size < 1:
+            raise ValueError("frequencies should be a 1-d array of at least one value")
+        if np.any(frequencies <= 0.):
+            raise ValueError("frequencies should be positive (in Hz)")
+        self.specific_energy_nu_frequencies = np.sort(frequencies)
 
 
     def set_mrw(self, mrw, gamma=1.0, inter_max=1000, warn=True):
@@ -772,7 +763,7 @@ class RunConf(object):
         self._read_max_reabsorptions(group)
         self._read_pda(group)
         self._read_mrw(group)
-        self._read_isrf(group)
+        self._read_specific_energy_nu_frequencies(group)
         self._read_convergence(group)
         self._read_kill_on_absorb(group)
         self._read_kill_on_scatter(group)
@@ -801,7 +792,7 @@ class RunConf(object):
         self._write_max_reabsorptions(group)
         self._write_pda(group)
         self._write_mrw(group)
-        self._write_isrf(group)
+        self._write_specific_energy_nu_frequencies(group)
         self._write_convergence(group)
         self._write_kill_on_absorb(group)
         self._write_kill_on_scatter(group)

--- a/hyperion/conf/conf_files.py
+++ b/hyperion/conf/conf_files.py
@@ -402,15 +402,24 @@ class RunConf(object):
     def _write_isrf(self,group):
         group.attrs['isrf'] = bool2str(self.isrf)
 
-    def compute_isrf(self,isrf):
+    def compute_isrf(self, isrf):
 
         '''
+        Set whether to compute and save the interstellar radiation field (ISRF)
+        in each cell.
 
-        Set whether or not to compute and save the ISRF in each cell
+        If enabled, the specific energy absorbed is also accumulated as a
+        function of frequency and saved as the ``specific_energy_nu`` quantity
+        (in erg/s/g), alongside the ``ISRF_frequency_bins`` array giving the
+        corresponding frequencies (in Hz). The frequency grid is taken from the
+        first dust type, so all dust types should share the same frequency grid.
+        These arrays are written following the ``output_specific_energy``
+        setting. This is disabled by default.
 
-        If enabled, the ISRF is computed in every cell at the
-        frequencies of the dust opacity tables.
-
+        Parameters
+        ----------
+        isrf : bool
+            Whether to compute and save the ISRF in each cell.
         '''
         self.isrf = isrf
 

--- a/hyperion/conf/conf_files.py
+++ b/hyperion/conf/conf_files.py
@@ -36,7 +36,7 @@ class OutputConf(FreezableClass):
         group.attrs['output_density'] = np.bytes_(self.output_density.encode('utf-8'))
         group.attrs['output_density_diff'] = np.bytes_(self.output_density_diff.encode('utf-8'))
         group.attrs['output_specific_energy'] = np.bytes_(self.output_specific_energy.encode('utf-8'))
-        group.attrs['output_specific_energy_nu'] = np.bytes_(self.output_specific_energ_nu.encode('utf-8'))
+        group.attrs['output_specific_energy_nu'] = np.bytes_(self.output_specific_energy_nu.encode('utf-8'))
         group.attrs['output_n_photons'] = np.bytes_(self.output_n_photons.encode('utf-8'))
 
 

--- a/hyperion/conf/tests/test_conf_io.py
+++ b/hyperion/conf/tests/test_conf_io.py
@@ -249,6 +249,16 @@ def test_io_run_conf_mrw(value):
     r2.read_run_conf(v)
     assert r2.mrw == r1.mrw
 
+@pytest.mark.parametrize(('value'), [True, False])
+def test_io_run_conf_isrf(value):
+    r1 = RunConf()
+    r1.compute_isrf(value)
+    r1.set_n_photons(1, 2)
+    v = virtual_file()
+    r1.write_run_conf(v)
+    r2 = RunConf()
+    r2.read_run_conf(v)
+    assert r2.isrf == r1.isrf
 
 @pytest.mark.parametrize(('value'), [False, True])
 def test_io_run_conf_convergence(value):

--- a/hyperion/conf/tests/test_conf_io.py
+++ b/hyperion/conf/tests/test_conf_io.py
@@ -4,6 +4,7 @@ from __future__ import print_function, division
 
 from itertools import product
 
+import numpy as np
 from numpy.testing import assert_equal
 import pytest
 
@@ -13,7 +14,8 @@ from ...util.functions import virtual_file
 
 @pytest.mark.parametrize(('attribute', 'value'),
                          list(product(['output_density', 'output_density_diff',
-                                       'output_specific_energy', 'output_n_photons'],
+                                       'output_specific_energy', 'output_specific_energy_nu',
+                                       'output_n_photons'],
                                       ['none', 'last', 'all'])))
 def test_io_output_conf(attribute, value):
     o1 = OutputConf()
@@ -249,16 +251,16 @@ def test_io_run_conf_mrw(value):
     r2.read_run_conf(v)
     assert r2.mrw == r1.mrw
 
-@pytest.mark.parametrize(('value'), [True, False])
-def test_io_run_conf_isrf(value):
+def test_io_run_conf_specific_energy_nu_frequencies():
     r1 = RunConf()
-    r1.compute_isrf(value)
+    r1.set_specific_energy_nu_frequencies(np.logspace(11., 16., 10))
     r1.set_n_photons(1, 2)
     v = virtual_file()
     r1.write_run_conf(v)
     r2 = RunConf()
     r2.read_run_conf(v)
-    assert r2.isrf == r1.isrf
+    np.testing.assert_allclose(r2.specific_energy_nu_frequencies,
+                               r1.specific_energy_nu_frequencies)
 
 @pytest.mark.parametrize(('value'), [False, True])
 def test_io_run_conf_convergence(value):

--- a/hyperion/conf/tests/test_conf_io.py
+++ b/hyperion/conf/tests/test_conf_io.py
@@ -14,7 +14,7 @@ from ...util.functions import virtual_file
 
 @pytest.mark.parametrize(('attribute', 'value'),
                          list(product(['output_density', 'output_density_diff',
-                                       'output_specific_energy', 'output_specific_energy_nu',
+                                       'output_specific_energy', 'output_specific_energy_spectrum',
                                        'output_n_photons'],
                                       ['none', 'last', 'all'])))
 def test_io_output_conf(attribute, value):
@@ -251,16 +251,16 @@ def test_io_run_conf_mrw(value):
     r2.read_run_conf(v)
     assert r2.mrw == r1.mrw
 
-def test_io_run_conf_specific_energy_nu_frequencies():
+def test_io_run_conf_specific_energy_spectrum_frequencies():
     r1 = RunConf()
-    r1.set_specific_energy_nu_frequencies(np.logspace(11., 16., 10))
+    r1.set_specific_energy_spectrum_frequencies(np.logspace(11., 16., 10))
     r1.set_n_photons(1, 2)
     v = virtual_file()
     r1.write_run_conf(v)
     r2 = RunConf()
     r2.read_run_conf(v)
-    np.testing.assert_allclose(r2.specific_energy_nu_frequencies,
-                               r1.specific_energy_nu_frequencies)
+    np.testing.assert_allclose(r2.specific_energy_spectrum_frequencies,
+                               r1.specific_energy_spectrum_frequencies)
 
 @pytest.mark.parametrize(('value'), [False, True])
 def test_io_run_conf_convergence(value):

--- a/hyperion/grid/cartesian_grid.py
+++ b/hyperion/grid/cartesian_grid.py
@@ -279,6 +279,8 @@ class CartesianGrid(FreezableClass):
         # Read in physical quantities
         if quantities is not None:
             for quantity in group:
+                if quantity == 'ISRF_frequency_bins':
+                    continue  # per-frequency metadata, not a per-cell grid quantity
                 if quantities == 'all' or quantity in quantities:
                     array = np.array(group[quantity])
                     if array.ndim == 4:  # if array is 4D, it is a list of 3D arrays

--- a/hyperion/grid/cartesian_grid.py
+++ b/hyperion/grid/cartesian_grid.py
@@ -279,7 +279,7 @@ class CartesianGrid(FreezableClass):
         # Read in physical quantities
         if quantities is not None:
             for quantity in group:
-                if quantity == 'specific_energy_nu_frequencies':
+                if quantity == 'specific_energy_spectrum_frequencies':
                     continue  # per-frequency metadata, not a per-cell grid quantity
                 if quantities == 'all' or quantity in quantities:
                     array = np.array(group[quantity])

--- a/hyperion/grid/cartesian_grid.py
+++ b/hyperion/grid/cartesian_grid.py
@@ -279,7 +279,7 @@ class CartesianGrid(FreezableClass):
         # Read in physical quantities
         if quantities is not None:
             for quantity in group:
-                if quantity == 'ISRF_frequency_bins':
+                if quantity == 'specific_energy_nu_frequencies':
                     continue  # per-frequency metadata, not a per-cell grid quantity
                 if quantities == 'all' or quantity in quantities:
                     array = np.array(group[quantity])

--- a/hyperion/grid/cylindrical_polar_grid.py
+++ b/hyperion/grid/cylindrical_polar_grid.py
@@ -307,7 +307,7 @@ class CylindricalPolarGrid(FreezableClass):
         # Read in physical quantities
         if quantities is not None:
             for quantity in group:
-                if quantity == 'specific_energy_nu_frequencies':
+                if quantity == 'specific_energy_spectrum_frequencies':
                     continue  # per-frequency metadata, not a per-cell grid quantity
                 if quantities == 'all' or quantity in quantities:
                     array = np.array(group[quantity])

--- a/hyperion/grid/cylindrical_polar_grid.py
+++ b/hyperion/grid/cylindrical_polar_grid.py
@@ -307,7 +307,7 @@ class CylindricalPolarGrid(FreezableClass):
         # Read in physical quantities
         if quantities is not None:
             for quantity in group:
-                if quantity == 'ISRF_frequency_bins':
+                if quantity == 'specific_energy_nu_frequencies':
                     continue  # per-frequency metadata, not a per-cell grid quantity
                 if quantities == 'all' or quantity in quantities:
                     array = np.array(group[quantity])

--- a/hyperion/grid/cylindrical_polar_grid.py
+++ b/hyperion/grid/cylindrical_polar_grid.py
@@ -307,6 +307,8 @@ class CylindricalPolarGrid(FreezableClass):
         # Read in physical quantities
         if quantities is not None:
             for quantity in group:
+                if quantity == 'ISRF_frequency_bins':
+                    continue  # per-frequency metadata, not a per-cell grid quantity
                 if quantities == 'all' or quantity in quantities:
                     array = np.array(group[quantity])
                     if array.ndim == 4:  # if array is 4D, it is a list of 3D arrays

--- a/hyperion/grid/grid_helpers.py
+++ b/hyperion/grid/grid_helpers.py
@@ -22,7 +22,7 @@ def single_grid_dims(data, ndim=3):
     '''
 
     if type(data) in [list, tuple]:
-
+        
         n_pop = len(data)
         shape = None
         for item in data:
@@ -34,14 +34,22 @@ def single_grid_dims(data, ndim=3):
         if shape is not None and len(shape) != ndim:
             raise ValueError("Grids should be %i-dimensional" % ndim)
 
-    elif isinstance(data, np.ndarray):
 
+
+    elif isinstance(data, np.ndarray):
         if data.ndim == ndim:
             n_pop = None
             shape = data.shape
         elif data.ndim == ndim + 1:
             n_pop = data.shape[0]
             shape = data[0].shape
+            
+        #DN CRAZY ADDITIONS
+        elif data.ndim == ndim+2:
+            n_pop = data.shape[1]
+            shape = data.shape[-1]
+            shape = tuple(map(int,str(shape).split(' ')))
+
         else:
             raise Exception("Unexpected number of dimensions: %i" % data.ndim)
 

--- a/hyperion/grid/grid_helpers.py
+++ b/hyperion/grid/grid_helpers.py
@@ -43,12 +43,11 @@ def single_grid_dims(data, ndim=3):
         elif data.ndim == ndim + 1:
             n_pop = data.shape[0]
             shape = data[0].shape
-            
-        #DN CRAZY ADDITIONS
-        elif data.ndim == ndim+2:
+
+        elif data.ndim == ndim + 2:
+            # Frequency-resolved quantity, stored as (n_freq, n_pop, *grid)
             n_pop = data.shape[1]
-            shape = data.shape[-1]
-            shape = tuple(map(int,str(shape).split(' ')))
+            shape = data.shape[-ndim:]
 
         else:
             raise Exception("Unexpected number of dimensions: %i" % data.ndim)
@@ -64,6 +63,9 @@ def single_grid_dims(data, ndim=3):
         elif len(shape) == ndim + 1:
             n_pop = shape[0]
             shape = shape[1:]
+        elif len(shape) == ndim + 2:
+            n_pop = shape[1]
+            shape = shape[-ndim:]
         else:
             raise Exception("Unexpected number of dimensions: %i" % len(shape))
     else:

--- a/hyperion/grid/octree_grid.py
+++ b/hyperion/grid/octree_grid.py
@@ -372,7 +372,7 @@ class OctreeGrid(FreezableClass):
         # Read in physical quantities
         if quantities is not None:
             for quantity in group:
-                if quantity == 'ISRF_frequency_bins':
+                if quantity == 'specific_energy_nu_frequencies':
                     continue  # per-frequency metadata, not a per-cell grid quantity
                 if quantities == 'all' or quantity in quantities:
                     array = np.array(group[quantity])

--- a/hyperion/grid/octree_grid.py
+++ b/hyperion/grid/octree_grid.py
@@ -372,7 +372,7 @@ class OctreeGrid(FreezableClass):
         # Read in physical quantities
         if quantities is not None:
             for quantity in group:
-                if quantity == 'specific_energy_nu_frequencies':
+                if quantity == 'specific_energy_spectrum_frequencies':
                     continue  # per-frequency metadata, not a per-cell grid quantity
                 if quantities == 'all' or quantity in quantities:
                     array = np.array(group[quantity])

--- a/hyperion/grid/octree_grid.py
+++ b/hyperion/grid/octree_grid.py
@@ -372,6 +372,8 @@ class OctreeGrid(FreezableClass):
         # Read in physical quantities
         if quantities is not None:
             for quantity in group:
+                if quantity == 'ISRF_frequency_bins':
+                    continue  # per-frequency metadata, not a per-cell grid quantity
                 if quantities == 'all' or quantity in quantities:
                     array = np.array(group[quantity])
                     if array.ndim == 2:  # if array is 2D, it is a list of 1D arrays

--- a/hyperion/grid/spherical_polar_grid.py
+++ b/hyperion/grid/spherical_polar_grid.py
@@ -317,7 +317,7 @@ class SphericalPolarGrid(FreezableClass):
         # Read in physical quantities
         if quantities is not None:
             for quantity in group:
-                if quantity == 'ISRF_frequency_bins':
+                if quantity == 'specific_energy_nu_frequencies':
                     continue  # per-frequency metadata, not a per-cell grid quantity
                 if quantities == 'all' or quantity in quantities:
                     array = np.array(group[quantity])

--- a/hyperion/grid/spherical_polar_grid.py
+++ b/hyperion/grid/spherical_polar_grid.py
@@ -317,7 +317,7 @@ class SphericalPolarGrid(FreezableClass):
         # Read in physical quantities
         if quantities is not None:
             for quantity in group:
-                if quantity == 'specific_energy_nu_frequencies':
+                if quantity == 'specific_energy_spectrum_frequencies':
                     continue  # per-frequency metadata, not a per-cell grid quantity
                 if quantities == 'all' or quantity in quantities:
                     array = np.array(group[quantity])

--- a/hyperion/grid/spherical_polar_grid.py
+++ b/hyperion/grid/spherical_polar_grid.py
@@ -317,6 +317,8 @@ class SphericalPolarGrid(FreezableClass):
         # Read in physical quantities
         if quantities is not None:
             for quantity in group:
+                if quantity == 'ISRF_frequency_bins':
+                    continue  # per-frequency metadata, not a per-cell grid quantity
                 if quantities == 'all' or quantity in quantities:
                     array = np.array(group[quantity])
                     if array.ndim == 4:  # if array is 4D, it is a list of 3D arrays

--- a/hyperion/grid/voronoi_grid.py
+++ b/hyperion/grid/voronoi_grid.py
@@ -396,7 +396,7 @@ class VoronoiGrid(FreezableClass):
         # Read in physical quantities
         if quantities is not None:
             for quantity in group:
-                if quantity == 'specific_energy_nu_frequencies':
+                if quantity == 'specific_energy_spectrum_frequencies':
                     continue  # per-frequency metadata, not a per-cell grid quantity
                 if quantities == 'all' or quantity in quantities:
                     array = np.array(group[quantity])

--- a/hyperion/grid/voronoi_grid.py
+++ b/hyperion/grid/voronoi_grid.py
@@ -396,7 +396,7 @@ class VoronoiGrid(FreezableClass):
         # Read in physical quantities
         if quantities is not None:
             for quantity in group:
-                if quantity == 'ISRF_frequency_bins':
+                if quantity == 'specific_energy_nu_frequencies':
                     continue  # per-frequency metadata, not a per-cell grid quantity
                 if quantities == 'all' or quantity in quantities:
                     array = np.array(group[quantity])

--- a/hyperion/grid/voronoi_grid.py
+++ b/hyperion/grid/voronoi_grid.py
@@ -396,6 +396,8 @@ class VoronoiGrid(FreezableClass):
         # Read in physical quantities
         if quantities is not None:
             for quantity in group:
+                if quantity == 'ISRF_frequency_bins':
+                    continue  # per-frequency metadata, not a per-cell grid quantity
                 if quantities == 'all' or quantity in quantities:
                     array = np.array(group[quantity])
                     if array.ndim == 2:  # if array is 2D, it is a list of 1D arrays

--- a/hyperion/grid/yt3_wrappers.py
+++ b/hyperion/grid/yt3_wrappers.py
@@ -79,6 +79,9 @@ def amr_grid_to_yt_stream(levels, dust_id=0):
             grid_dict['level'] = ilevel
 
             for field in grid.quantities:
+                if not isinstance(grid.quantities[field], list):
+                    logger.warning("Skipping frequency-resolved quantity '{0}' in yt export (select a single frequency first)".format(field))
+                    continue
                 grid_dict[('gas', field)] = grid.quantities[field][dust_id].transpose()
 
             grid_data.append(grid_dict)
@@ -158,6 +161,9 @@ def octree_grid_to_yt_stream(grid, dust_id=0):
 
     quantities = {}
     for field in grid.quantities:
+        if not isinstance(grid.quantities[field], list):
+            logger.warning("Skipping frequency-resolved quantity '{0}' in yt export (select a single frequency first)".format(field))
+            continue
         quantities[('gas', field)] = np.atleast_2d(grid.quantities[field][dust_id][order][~refined]).transpose()
 
     bbox = np.array([[xmin, xmax], [ymin, ymax], [zmin, zmax]])
@@ -180,6 +186,9 @@ def cartesian_grid_to_yt_stream(grid, xmin, xmax, ymin, ymax, zmin, zmax, dust_i
     # Make data dict which should contain (array, unit) tuples
     data = {}
     for field in grid.quantities:
+        if not isinstance(grid.quantities[field], list):
+            logger.warning("Skipping frequency-resolved quantity '{0}' in yt export (select a single frequency first)".format(field))
+            continue
         data[field] = grid.quantities[field][dust_id].transpose(), ''
 
     # Load cartesian grid into yt

--- a/hyperion/model/model.py
+++ b/hyperion/model/model.py
@@ -223,7 +223,7 @@ class Model(FreezableClass, RunConf):
         # Close the file
         f.close()
 
-    def use_quantities(self, filename, quantities=['density', 'specific_energy'],
+    def use_quantities(self, filename, quantities=['density', 'specific_energy', 'specific_energy_nu'],
                        use_minimum_specific_energy=True, use_dust=True, copy=True,
                        only_initial=False):
         '''
@@ -296,6 +296,13 @@ class Model(FreezableClass, RunConf):
                         quantities_path['specific_energy'] = '/Input/Grid/Quantities'
                 else:
                     quantities_path['specific_energy'] = last_iteration
+
+            if 'specific_energy_nu' in quantities:
+                if only_initial or last_iteration is None:
+                    if 'specific_energy_nu' in f['/Input/Grid/Quantities']:
+                        quantities_path['specific_energy_nu'] = '/Input/Grid/Quantities'
+                else:
+                    quantities_path['specific_energy_nu'] = last_iteration
 
             # Minimum specific energy
             if use_minimum_specific_energy:
@@ -812,6 +819,7 @@ class Model(FreezableClass, RunConf):
             self.grid['density'] = []
             if specific_energy is not None:
                 self.grid['specific_energy'] = []
+                self.grid['specific_energy_nu'] = []
 
         # Check whether the density can be added to an existing one
         if merge_if_possible:
@@ -853,6 +861,7 @@ class Model(FreezableClass, RunConf):
         # Set specific energy if specified
         if specific_energy is not None:
             self.grid['specific_energy'].append(specific_energy)
+            self.grid['specific_energy_nu'].append(specific_energy)
 
     def set_cartesian_grid(self, x_wall, y_wall, z_wall):
         self.set_grid(CartesianGrid(x_wall, y_wall, z_wall))

--- a/hyperion/model/model.py
+++ b/hyperion/model/model.py
@@ -297,12 +297,13 @@ class Model(FreezableClass, RunConf):
                 else:
                     quantities_path['specific_energy'] = last_iteration
 
-            if 'specific_energy_nu' in quantities:
-                if only_initial or last_iteration is None:
-                    if 'specific_energy_nu' in f['/Input/Grid/Quantities']:
-                        quantities_path['specific_energy_nu'] = '/Input/Grid/Quantities'
-                else:
-                    quantities_path['specific_energy_nu'] = last_iteration
+            if self.compute_isrf == True:
+                if 'specific_energy_nu' in quantities:
+                    if only_initial or last_iteration is None:
+                        if 'specific_energy_nu' in f['/Input/Grid/Quantities']:
+                            quantities_path['specific_energy_nu'] = '/Input/Grid/Quantities'
+                    else:
+                        quantities_path['specific_energy_nu'] = last_iteration
 
             # Minimum specific energy
             if use_minimum_specific_energy:
@@ -320,10 +321,11 @@ class Model(FreezableClass, RunConf):
                 if 'specific_energy' in f['/Grid/Quantities']:
                     quantities_path['specific_energy'] = '/Grid/Quantities'
 
-            if 'specific_energy_nu' in quantities:
-                if 'specific_energy_nu' in f['/Grid/Quantities']:
-                    quantities_path['specific_energy_nu'] = '/Grid/Quantities'
-
+            if self.compute_isrf == True:
+                if 'specific_energy_nu' in quantities:
+                    if 'specific_energy_nu' in f['/Grid/Quantities']:
+                        quantities_path['specific_energy_nu'] = '/Grid/Quantities'
+                        
             # Minimum specific energy
             if use_minimum_specific_energy:
                 minimum_specific_energy_path = '/Grid/Quantities'
@@ -819,7 +821,9 @@ class Model(FreezableClass, RunConf):
             self.grid['density'] = []
             if specific_energy is not None:
                 self.grid['specific_energy'] = []
-                self.grid['specific_energy_nu'] = []
+                
+                if self.compute_isrf == True:
+                    self.grid['specific_energy_nu'] = []
 
         # Check whether the density can be added to an existing one
         if merge_if_possible:
@@ -861,7 +865,9 @@ class Model(FreezableClass, RunConf):
         # Set specific energy if specified
         if specific_energy is not None:
             self.grid['specific_energy'].append(specific_energy)
-            self.grid['specific_energy_nu'].append(specific_energy)
+            
+            if self.compute_isrf == True:
+                self.grid['specific_energy_nu'].append(specific_energy)
 
     def set_cartesian_grid(self, x_wall, y_wall, z_wall):
         self.set_grid(CartesianGrid(x_wall, y_wall, z_wall))

--- a/hyperion/model/model.py
+++ b/hyperion/model/model.py
@@ -313,6 +313,10 @@ class Model(FreezableClass, RunConf):
                 if 'specific_energy' in f['/Grid/Quantities']:
                     quantities_path['specific_energy'] = '/Grid/Quantities'
 
+            if 'specific_energy_nu' in quantities:
+                if 'specific_energy_nu' in f['/Grid/Quantities']:
+                    quantities_path['specific_energy_nu'] = '/Grid/Quantities'
+
             # Minimum specific energy
             if use_minimum_specific_energy:
                 minimum_specific_energy_path = '/Grid/Quantities'

--- a/hyperion/model/model.py
+++ b/hyperion/model/model.py
@@ -297,13 +297,12 @@ class Model(FreezableClass, RunConf):
                 else:
                     quantities_path['specific_energy'] = last_iteration
 
-            if self.compute_isrf == True:
-                if 'specific_energy_nu' in quantities:
-                    if only_initial or last_iteration is None:
-                        if 'specific_energy_nu' in f['/Input/Grid/Quantities']:
-                            quantities_path['specific_energy_nu'] = '/Input/Grid/Quantities'
-                    else:
-                        quantities_path['specific_energy_nu'] = last_iteration
+            if 'specific_energy_nu' in quantities:
+                if only_initial or last_iteration is None:
+                    if 'specific_energy_nu' in f['/Input/Grid/Quantities']:
+                        quantities_path['specific_energy_nu'] = '/Input/Grid/Quantities'
+                elif 'specific_energy_nu' in f[last_iteration]:
+                    quantities_path['specific_energy_nu'] = last_iteration
 
             # Minimum specific energy
             if use_minimum_specific_energy:
@@ -321,11 +320,10 @@ class Model(FreezableClass, RunConf):
                 if 'specific_energy' in f['/Grid/Quantities']:
                     quantities_path['specific_energy'] = '/Grid/Quantities'
 
-            if self.compute_isrf == True:
-                if 'specific_energy_nu' in quantities:
-                    if 'specific_energy_nu' in f['/Grid/Quantities']:
-                        quantities_path['specific_energy_nu'] = '/Grid/Quantities'
-                        
+            if 'specific_energy_nu' in quantities:
+                if 'specific_energy_nu' in f['/Grid/Quantities']:
+                    quantities_path['specific_energy_nu'] = '/Grid/Quantities'
+
             # Minimum specific energy
             if use_minimum_specific_energy:
                 minimum_specific_energy_path = '/Grid/Quantities'

--- a/hyperion/model/model.py
+++ b/hyperion/model/model.py
@@ -223,7 +223,7 @@ class Model(FreezableClass, RunConf):
         # Close the file
         f.close()
 
-    def use_quantities(self, filename, quantities=['density', 'specific_energy', 'specific_energy_nu'],
+    def use_quantities(self, filename, quantities=['density', 'specific_energy', 'specific_energy_spectrum'],
                        use_minimum_specific_energy=True, use_dust=True, copy=True,
                        only_initial=False):
         '''
@@ -297,12 +297,12 @@ class Model(FreezableClass, RunConf):
                 else:
                     quantities_path['specific_energy'] = last_iteration
 
-            if 'specific_energy_nu' in quantities:
+            if 'specific_energy_spectrum' in quantities:
                 if only_initial or last_iteration is None:
-                    if 'specific_energy_nu' in f['/Input/Grid/Quantities']:
-                        quantities_path['specific_energy_nu'] = '/Input/Grid/Quantities'
-                elif 'specific_energy_nu' in f[last_iteration]:
-                    quantities_path['specific_energy_nu'] = last_iteration
+                    if 'specific_energy_spectrum' in f['/Input/Grid/Quantities']:
+                        quantities_path['specific_energy_spectrum'] = '/Input/Grid/Quantities'
+                elif 'specific_energy_spectrum' in f[last_iteration]:
+                    quantities_path['specific_energy_spectrum'] = last_iteration
 
             # Minimum specific energy
             if use_minimum_specific_energy:
@@ -320,9 +320,9 @@ class Model(FreezableClass, RunConf):
                 if 'specific_energy' in f['/Grid/Quantities']:
                     quantities_path['specific_energy'] = '/Grid/Quantities'
 
-            if 'specific_energy_nu' in quantities:
-                if 'specific_energy_nu' in f['/Grid/Quantities']:
-                    quantities_path['specific_energy_nu'] = '/Grid/Quantities'
+            if 'specific_energy_spectrum' in quantities:
+                if 'specific_energy_spectrum' in f['/Grid/Quantities']:
+                    quantities_path['specific_energy_spectrum'] = '/Grid/Quantities'
 
             # Minimum specific energy
             if use_minimum_specific_energy:

--- a/hyperion/model/model.py
+++ b/hyperion/model/model.py
@@ -819,9 +819,6 @@ class Model(FreezableClass, RunConf):
             self.grid['density'] = []
             if specific_energy is not None:
                 self.grid['specific_energy'] = []
-                
-                if self.compute_isrf == True:
-                    self.grid['specific_energy_nu'] = []
 
         # Check whether the density can be added to an existing one
         if merge_if_possible:
@@ -863,9 +860,6 @@ class Model(FreezableClass, RunConf):
         # Set specific energy if specified
         if specific_energy is not None:
             self.grid['specific_energy'].append(specific_energy)
-            
-            if self.compute_isrf == True:
-                self.grid['specific_energy_nu'].append(specific_energy)
 
     def set_cartesian_grid(self, x_wall, y_wall, z_wall):
         self.set_grid(CartesianGrid(x_wall, y_wall, z_wall))

--- a/hyperion/model/tests/test_isrf.py
+++ b/hyperion/model/tests/test_isrf.py
@@ -232,6 +232,23 @@ def test_isrf_get_quantities(tmpdir):
 
 
 @pytest.mark.requires_hyperion_binaries
+def test_isrf_yt_export_skips_frequency_resolved(tmpdir):
+    # The frequency-resolved specific_energy_nu is not a per-cell scalar, so it
+    # must be skipped (not exported as a malformed field) when converting to yt,
+    # while the ordinary scalar quantities are still exported.
+    pytest.importorskip("yt")
+    m = _cartesian_isrf_model(True, density=1.e-16)
+    m.write(tmpdir.join(random_id()).strpath)
+    out = m.run(tmpdir.join(random_id()).strpath)
+    g = out.get_quantities()
+    assert 'specific_energy_nu' in g.quantities
+    ds = g.to_yt()
+    fields = [str(f) for f in ds.field_list]
+    assert not any('specific_energy_nu' in f for f in fields)
+    assert any(f.endswith("'density')") for f in fields)
+
+
+@pytest.mark.requires_hyperion_binaries
 def test_isrf_mpi_matches_serial(tmpdir):
     # The saved ISRF must not depend on the number of MPI processes. We compare
     # the total ISRF energy (which is conserved, hence robust to Monte Carlo

--- a/hyperion/model/tests/test_isrf.py
+++ b/hyperion/model/tests/test_isrf.py
@@ -188,6 +188,25 @@ def test_isrf_frequencies_validation():
 
 
 @pytest.mark.requires_hyperion_binaries
+def test_isrf_get_quantities(tmpdir):
+    # specific_energy_nu should be retrievable through get_quantities, the
+    # per-frequency ISRF_frequency_bins metadata should not pollute the grid
+    # quantities, and the retrieved array should still conserve energy.
+    m = _cartesian_isrf_model(True, density=1.e-16)
+    m.write(tmpdir.join(random_id()).strpath)
+    out = m.run(tmpdir.join(random_id()).strpath)
+    g = out.get_quantities()
+    assert 'specific_energy_nu' in g.quantities
+    assert 'ISRF_frequency_bins' not in g.quantities
+    se = np.array(g.quantities['specific_energy'])       # (dust, nz, ny, nx)
+    se_nu = np.array(g.quantities['specific_energy_nu'])  # (nu, dust, nz, ny, nx)
+    assert se_nu.shape[0] == 2  # number of dust frequencies
+    nu_sum = se_nu.sum(axis=0)
+    heated = se > se.min() * (1. + 1.e-6)
+    np.testing.assert_allclose(nu_sum[heated], se[heated], rtol=1.e-6)
+
+
+@pytest.mark.requires_hyperion_binaries
 def test_isrf_mpi_matches_serial(tmpdir):
     # The saved ISRF must not depend on the number of MPI processes. We compare
     # the total ISRF energy (which is conserved, hence robust to Monte Carlo

--- a/hyperion/model/tests/test_isrf.py
+++ b/hyperion/model/tests/test_isrf.py
@@ -1,0 +1,163 @@
+from __future__ import print_function, division
+
+import shutil
+
+import numpy as np
+import pytest
+
+import h5py
+
+from .. import Model
+from ...grid import AMRGrid
+from ...util.functions import random_id
+from .test_helpers import get_test_dust
+
+
+def _read_dataset(filename, suffix):
+    """Return the last grid dataset whose HDF5 path ends with ``suffix``."""
+    with h5py.File(filename, 'r') as f:
+        matches = []
+        f.visititems(lambda name, obj: matches.append(name)
+                     if name.endswith(suffix) and isinstance(obj, h5py.Dataset)
+                     else None)
+        if not matches:
+            return None
+        return np.asarray(f[matches[-1]][()], dtype=float)
+
+
+def _assert_isrf_reconstructs_specific_energy(filename):
+    # Summed over frequency, the ISRF must reproduce the specific energy. Cells
+    # with no absorption are clamped up to the minimum specific energy (which
+    # only affects specific_energy, not the unclamped specific_energy_nu), so we
+    # compare only cells that were genuinely heated above that floor.
+    se = _read_dataset(filename, '/specific_energy')
+    se_nu = _read_dataset(filename, '/specific_energy_nu')
+    assert se_nu is not None
+    nu_sum = se_nu.sum(axis=0)
+    floor = se.min()
+    heated = se > floor * (1. + 1.e-6)
+    assert np.count_nonzero(heated) >= 1
+    np.testing.assert_allclose(nu_sum[heated], se[heated], rtol=1.e-6)
+
+
+def _cartesian_isrf_model(compute_isrf, n_cells=2, n_photons=100000, density=1.e-18):
+    m = Model()
+    edges = np.linspace(-1., 1., n_cells + 1)
+    m.set_cartesian_grid(edges, edges, edges)
+    dust = get_test_dust()
+    m.add_density_grid(np.ones((n_cells, n_cells, n_cells)) * density, dust)
+    s = m.add_point_source()
+    s.luminosity = 1.
+    s.temperature = 6000.
+    m.set_n_initial_iterations(3)
+    m.set_n_photons(initial=n_photons, imaging=0)
+    m.set_seed(-12345)
+    m.conf.output.output_specific_energy = 'last'
+    m.compute_isrf(compute_isrf)
+    return m
+
+
+@pytest.mark.requires_hyperion_binaries
+def test_isrf_does_not_change_specific_energy(tmpdir):
+    # Computing the ISRF must not perturb the ordinary specific-energy
+    # (temperature) calculation. This guards against the regression where the
+    # specific_energy_sum accumulation was accidentally gated behind compute_isrf.
+    se = {}
+    for isrf in (False, True):
+        m = _cartesian_isrf_model(isrf)
+        m.write(tmpdir.join(random_id()).strpath)
+        out = m.run(tmpdir.join(random_id()).strpath)
+        se[isrf] = _read_dataset(out.filename, '/specific_energy')
+    # Same seed, and the ISRF code path does not touch the random stream, so
+    # the specific energy should be identical with and without the ISRF.
+    np.testing.assert_allclose(se[True], se[False], rtol=1.e-10)
+
+
+@pytest.mark.requires_hyperion_binaries
+def test_isrf_sums_to_specific_energy(tmpdir):
+    # The frequency-resolved ISRF, summed over frequency, must reproduce the
+    # total specific energy.
+    m = _cartesian_isrf_model(True)
+    m.write(tmpdir.join(random_id()).strpath)
+    out = m.run(tmpdir.join(random_id()).strpath)
+    _assert_isrf_reconstructs_specific_energy(out.filename)
+
+
+@pytest.mark.requires_hyperion_binaries
+def test_isrf_frequency_bins_written(tmpdir):
+    # ISRF_frequency_bins is a per-frequency (1-D) quantity, not per-cell. This
+    # guards against the regression where it was written as a grid array, which
+    # segfaulted whenever the number of frequencies was smaller than n_cells.
+    m = _cartesian_isrf_model(True, n_cells=8)  # 512 cells, dust has 2 frequencies
+    m.write(tmpdir.join(random_id()).strpath)
+    out = m.run(tmpdir.join(random_id()).strpath)
+    bins = _read_dataset(out.filename, '/ISRF_frequency_bins')
+    assert bins is not None
+    assert bins.shape == (2,)  # == number of dust frequencies, not n_cells
+
+
+@pytest.mark.requires_hyperion_binaries
+def test_isrf_dustless_model_runs(tmpdir):
+    # A model with no dust must still run (and image) without crashing. This
+    # guards against the regression where ISRF instrumentation dereferenced the
+    # first dust type unconditionally, segfaulting dustless models.
+    m = Model()
+    m.set_cartesian_grid([-1., 1.], [-1., 1.], [-1., 1.])
+    s = m.add_point_source()
+    s.luminosity = 1.
+    s.temperature = 6000.
+    i = m.add_peeled_images(sed=True, image=False)
+    i.set_viewing_angles([45.], [45.])
+    i.set_wavelength_range(5, 0.1, 100.)
+    m.set_n_initial_iterations(0)
+    m.set_n_photons(imaging=10000)
+    m.write(tmpdir.join(random_id()).strpath)
+    # Should complete without raising (previously segfaulted in the final iteration).
+    m.run(tmpdir.join(random_id()).strpath)
+
+
+@pytest.mark.requires_hyperion_binaries
+def test_isrf_amr(tmpdir):
+    # The ISRF must work on AMR grids: it should run and, summed over frequency,
+    # reproduce the specific energy in every cell.
+    m = Model()
+    amr = AMRGrid()
+    level = amr.add_level()
+    grid = level.add_grid()
+    grid.xmin, grid.xmax = -1., 1.
+    grid.ymin, grid.ymax = -1., 1.
+    grid.zmin, grid.zmax = -1., 1.
+    grid.nx, grid.ny, grid.nz = 4, 4, 4
+    grid.quantities['density'] = [np.ones((4, 4, 4)) * 1.e-16]
+    m.set_amr_grid(amr)
+    m.add_density_grid(amr['density'][0], get_test_dust())
+    s = m.add_point_source()
+    s.luminosity = 1.
+    s.temperature = 6000.
+    m.set_n_initial_iterations(3)
+    m.set_n_photons(initial=100000, imaging=0)
+    m.set_seed(-9)
+    m.conf.output.output_specific_energy = 'last'
+    m.compute_isrf(True)
+    m.write(tmpdir.join(random_id()).strpath)
+    out = m.run(tmpdir.join(random_id()).strpath)
+    _assert_isrf_reconstructs_specific_energy(out.filename)
+
+
+@pytest.mark.requires_hyperion_binaries
+def test_isrf_mpi_matches_serial(tmpdir):
+    # The saved ISRF must not depend on the number of MPI processes. We compare
+    # the total ISRF energy (which is conserved, hence robust to Monte Carlo
+    # noise) between a serial run and a 2-process MPI run.
+    if shutil.which('mpirun') is None and shutil.which('mpiexec') is None:
+        pytest.skip("no MPI launcher available")
+
+    m = _cartesian_isrf_model(True, n_photons=200000)
+    m.write(tmpdir.join(random_id()).strpath)
+
+    out_serial = m.run(tmpdir.join(random_id()).strpath)
+    out_mpi = m.run(tmpdir.join(random_id()).strpath, mpi=True, n_processes=2)
+
+    total_serial = np.nansum(_read_dataset(out_serial.filename, '/specific_energy_nu'))
+    total_mpi = np.nansum(_read_dataset(out_mpi.filename, '/specific_energy_nu'))
+    np.testing.assert_allclose(total_mpi, total_serial, rtol=2.e-2)

--- a/hyperion/model/tests/test_isrf.py
+++ b/hyperion/model/tests/test_isrf.py
@@ -188,6 +188,31 @@ def test_isrf_frequencies_validation():
 
 
 @pytest.mark.requires_hyperion_binaries
+def test_isrf_voronoi(tmpdir):
+    # The ISRF must also work on (unstructured) Voronoi grids, where cells are a
+    # flat list rather than a structured grid.
+    rng = np.random.RandomState(12345)
+    n = 30
+    x = rng.uniform(-1., 1., n)
+    y = rng.uniform(-1., 1., n)
+    z = rng.uniform(-1., 1., n)
+    m = Model()
+    m.set_voronoi_grid(x, y, z)
+    m.add_density_grid(np.ones(n) * 1.e-16, get_test_dust())
+    s = m.add_point_source()
+    s.luminosity = 1.
+    s.temperature = 6000.
+    m.set_n_initial_iterations(3)
+    m.set_n_photons(initial=100000, imaging=0)
+    m.set_seed(-12345)
+    m.conf.output.output_specific_energy = 'last'
+    m.compute_isrf(True)
+    m.write(tmpdir.join(random_id()).strpath)
+    out = m.run(tmpdir.join(random_id()).strpath)
+    _assert_isrf_reconstructs_specific_energy(out.filename)
+
+
+@pytest.mark.requires_hyperion_binaries
 def test_isrf_get_quantities(tmpdir):
     # specific_energy_nu should be retrievable through get_quantities, the
     # per-frequency ISRF_frequency_bins metadata should not pollute the grid

--- a/hyperion/model/tests/test_isrf.py
+++ b/hyperion/model/tests/test_isrf.py
@@ -40,7 +40,8 @@ def _assert_isrf_reconstructs_specific_energy(filename):
     np.testing.assert_allclose(nu_sum[heated], se[heated], rtol=1.e-6)
 
 
-def _cartesian_isrf_model(compute_isrf, n_cells=2, n_photons=100000, density=1.e-18):
+def _cartesian_isrf_model(compute_isrf, n_cells=2, n_photons=100000, density=1.e-18,
+                          frequencies=None):
     m = Model()
     edges = np.linspace(-1., 1., n_cells + 1)
     m.set_cartesian_grid(edges, edges, edges)
@@ -53,7 +54,7 @@ def _cartesian_isrf_model(compute_isrf, n_cells=2, n_photons=100000, density=1.e
     m.set_n_photons(initial=n_photons, imaging=0)
     m.set_seed(-12345)
     m.conf.output.output_specific_energy = 'last'
-    m.compute_isrf(compute_isrf)
+    m.compute_isrf(compute_isrf, frequencies=frequencies)
     return m
 
 
@@ -142,6 +143,48 @@ def test_isrf_amr(tmpdir):
     m.write(tmpdir.join(random_id()).strpath)
     out = m.run(tmpdir.join(random_id()).strpath)
     _assert_isrf_reconstructs_specific_energy(out.filename)
+
+
+@pytest.mark.requires_hyperion_binaries
+def test_isrf_custom_frequency_grid(tmpdir):
+    # A user-specified ISRF frequency grid (independent of the dust frequency
+    # grid) should be used for the output bins, and energy must still be
+    # conserved when summing over frequency.
+    frequencies = np.logspace(10., 16., 12)
+    m = _cartesian_isrf_model(True, density=1.e-16, frequencies=frequencies)
+    m.write(tmpdir.join(random_id()).strpath)
+    out = m.run(tmpdir.join(random_id()).strpath)
+    bins = _read_dataset(out.filename, '/ISRF_frequency_bins')
+    np.testing.assert_allclose(bins, frequencies, rtol=1.e-6)
+    se_nu = _read_dataset(out.filename, '/specific_energy_nu')
+    assert se_nu.shape[0] == len(frequencies)
+    _assert_isrf_reconstructs_specific_energy(out.filename)
+
+
+def test_isrf_frequencies_roundtrip(tmpdir):
+    # The custom ISRF frequency grid should survive a write/read round-trip.
+    from ...conf.conf_files import RunConf
+    frequencies = np.logspace(10., 16., 8)
+    conf = RunConf()
+    conf.compute_isrf(True, frequencies=frequencies)
+    with h5py.File(tmpdir.join('conf.h5').strpath, 'w') as f:
+        conf._write_isrf(f)
+        conf2 = RunConf()
+        conf2._read_isrf(f)
+    assert conf2.isrf
+    np.testing.assert_allclose(conf2.isrf_frequencies, frequencies)
+
+
+def test_isrf_frequencies_validation():
+    from ...conf.conf_files import RunConf
+    conf = RunConf()
+    with pytest.raises(ValueError):
+        conf.compute_isrf(True, frequencies=[[1.e10, 1.e12], [1.e14, 1.e16]])
+    with pytest.raises(ValueError):
+        conf.compute_isrf(True, frequencies=[1.e10, -1.e12])
+    # Default (no custom grid) leaves isrf_frequencies unset
+    conf.compute_isrf(True)
+    assert conf.isrf_frequencies is None
 
 
 @pytest.mark.requires_hyperion_binaries

--- a/hyperion/model/tests/test_specific_energy_nu.py
+++ b/hyperion/model/tests/test_specific_energy_nu.py
@@ -25,11 +25,11 @@ def _read_dataset(filename, suffix):
         return np.asarray(f[matches[-1]][()], dtype=float)
 
 
-def _assert_isrf_reconstructs_specific_energy(filename):
-    # Summed over frequency, the ISRF must reproduce the specific energy. Cells
-    # with no absorption are clamped up to the minimum specific energy (which
-    # only affects specific_energy, not the unclamped specific_energy_nu), so we
-    # compare only cells that were genuinely heated above that floor.
+def _assert_nu_sums_to_specific_energy(filename):
+    # Summed over frequency, specific_energy_nu must reproduce specific_energy.
+    # Cells with no absorption are clamped up to the minimum specific energy
+    # (which only affects specific_energy, not the unclamped specific_energy_nu),
+    # so we compare only cells that were genuinely heated above that floor.
     se = _read_dataset(filename, '/specific_energy')
     se_nu = _read_dataset(filename, '/specific_energy_nu')
     assert se_nu is not None
@@ -40,8 +40,8 @@ def _assert_isrf_reconstructs_specific_energy(filename):
     np.testing.assert_allclose(nu_sum[heated], se[heated], rtol=1.e-6)
 
 
-def _cartesian_isrf_model(compute_isrf, n_cells=2, n_photons=100000, density=1.e-18,
-                          frequencies=None):
+def _cartesian_model(output_specific_energy_nu='last', n_cells=2, n_photons=100000,
+                     density=1.e-18, frequencies=None):
     m = Model()
     edges = np.linspace(-1., 1., n_cells + 1)
     m.set_cartesian_grid(edges, edges, edges)
@@ -54,53 +54,54 @@ def _cartesian_isrf_model(compute_isrf, n_cells=2, n_photons=100000, density=1.e
     m.set_n_photons(initial=n_photons, imaging=0)
     m.set_seed(-12345)
     m.conf.output.output_specific_energy = 'last'
-    m.compute_isrf(compute_isrf, frequencies=frequencies)
+    m.conf.output.output_specific_energy_nu = output_specific_energy_nu
+    if frequencies is not None:
+        m.set_specific_energy_nu_frequencies(frequencies)
     return m
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_isrf_does_not_change_specific_energy(tmpdir):
-    # Computing the ISRF must not perturb the ordinary specific-energy
-    # (temperature) calculation. This guards against the regression where the
-    # specific_energy_sum accumulation was accidentally gated behind compute_isrf.
+def test_specific_energy_nu_does_not_change_specific_energy(tmpdir):
+    # Computing the frequency-resolved specific energy must not perturb the
+    # ordinary specific-energy (temperature) calculation. This guards against the
+    # regression where specific_energy_sum accumulation was gated on the option.
     se = {}
-    for isrf in (False, True):
-        m = _cartesian_isrf_model(isrf)
+    for output in ('none', 'last'):
+        m = _cartesian_model(output_specific_energy_nu=output)
         m.write(tmpdir.join(random_id()).strpath)
         out = m.run(tmpdir.join(random_id()).strpath)
-        se[isrf] = _read_dataset(out.filename, '/specific_energy')
-    # Same seed, and the ISRF code path does not touch the random stream, so
-    # the specific energy should be identical with and without the ISRF.
-    np.testing.assert_allclose(se[True], se[False], rtol=1.e-10)
+        se[output] = _read_dataset(out.filename, '/specific_energy')
+    # Same seed, and the extra code path does not touch the random stream, so
+    # the specific energy should be identical with and without the option.
+    np.testing.assert_allclose(se['last'], se['none'], rtol=1.e-10)
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_isrf_sums_to_specific_energy(tmpdir):
-    # The frequency-resolved ISRF, summed over frequency, must reproduce the
-    # total specific energy.
-    m = _cartesian_isrf_model(True)
+def test_specific_energy_nu_sums_to_specific_energy(tmpdir):
+    # specific_energy_nu, summed over frequency, must reproduce specific_energy.
+    m = _cartesian_model('last')
     m.write(tmpdir.join(random_id()).strpath)
     out = m.run(tmpdir.join(random_id()).strpath)
-    _assert_isrf_reconstructs_specific_energy(out.filename)
+    _assert_nu_sums_to_specific_energy(out.filename)
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_isrf_frequency_bins_written(tmpdir):
-    # ISRF_frequency_bins is a per-frequency (1-D) quantity, not per-cell. This
-    # guards against the regression where it was written as a grid array, which
-    # segfaulted whenever the number of frequencies was smaller than n_cells.
-    m = _cartesian_isrf_model(True, n_cells=8)  # 512 cells, dust has 2 frequencies
+def test_specific_energy_nu_frequencies_written(tmpdir):
+    # specific_energy_nu_frequencies is a per-frequency (1-D) quantity, not
+    # per-cell. This guards against the regression where it was written as a grid
+    # array, which segfaulted whenever n_nu was smaller than n_cells.
+    m = _cartesian_model('last', n_cells=8)  # 512 cells, dust has 2 frequencies
     m.write(tmpdir.join(random_id()).strpath)
     out = m.run(tmpdir.join(random_id()).strpath)
-    bins = _read_dataset(out.filename, '/ISRF_frequency_bins')
+    bins = _read_dataset(out.filename, '/specific_energy_nu_frequencies')
     assert bins is not None
     assert bins.shape == (2,)  # == number of dust frequencies, not n_cells
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_isrf_dustless_model_runs(tmpdir):
+def test_specific_energy_nu_dustless_model_runs(tmpdir):
     # A model with no dust must still run (and image) without crashing. This
-    # guards against the regression where ISRF instrumentation dereferenced the
+    # guards against the regression where the instrumentation dereferenced the
     # first dust type unconditionally, segfaulting dustless models.
     m = Model()
     m.set_cartesian_grid([-1., 1.], [-1., 1.], [-1., 1.])
@@ -118,9 +119,9 @@ def test_isrf_dustless_model_runs(tmpdir):
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_isrf_amr(tmpdir):
-    # The ISRF must work on AMR grids: it should run and, summed over frequency,
-    # reproduce the specific energy in every cell.
+def test_specific_energy_nu_amr(tmpdir):
+    # specific_energy_nu must work on AMR grids: it should run and, summed over
+    # frequency, reproduce specific_energy in every cell.
     m = Model()
     amr = AMRGrid()
     level = amr.add_level()
@@ -139,58 +140,56 @@ def test_isrf_amr(tmpdir):
     m.set_n_photons(initial=100000, imaging=0)
     m.set_seed(-9)
     m.conf.output.output_specific_energy = 'last'
-    m.compute_isrf(True)
+    m.conf.output.output_specific_energy_nu = 'last'
     m.write(tmpdir.join(random_id()).strpath)
     out = m.run(tmpdir.join(random_id()).strpath)
-    _assert_isrf_reconstructs_specific_energy(out.filename)
+    _assert_nu_sums_to_specific_energy(out.filename)
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_isrf_custom_frequency_grid(tmpdir):
-    # A user-specified ISRF frequency grid (independent of the dust frequency
-    # grid) should be used for the output bins, and energy must still be
-    # conserved when summing over frequency.
+def test_specific_energy_nu_custom_frequency_grid(tmpdir):
+    # A user-specified frequency grid (independent of the dust frequency grid)
+    # should be used for the output bins, and energy must still be conserved
+    # when summing over frequency.
     frequencies = np.logspace(10., 16., 12)
-    m = _cartesian_isrf_model(True, density=1.e-16, frequencies=frequencies)
+    m = _cartesian_model('last', density=1.e-16, frequencies=frequencies)
     m.write(tmpdir.join(random_id()).strpath)
     out = m.run(tmpdir.join(random_id()).strpath)
-    bins = _read_dataset(out.filename, '/ISRF_frequency_bins')
+    bins = _read_dataset(out.filename, '/specific_energy_nu_frequencies')
     np.testing.assert_allclose(bins, frequencies, rtol=1.e-6)
     se_nu = _read_dataset(out.filename, '/specific_energy_nu')
     assert se_nu.shape[0] == len(frequencies)
-    _assert_isrf_reconstructs_specific_energy(out.filename)
+    _assert_nu_sums_to_specific_energy(out.filename)
 
 
-def test_isrf_frequencies_roundtrip(tmpdir):
-    # The custom ISRF frequency grid should survive a write/read round-trip.
+def test_specific_energy_nu_frequencies_roundtrip(tmpdir):
+    # The custom frequency grid should survive a write/read round-trip.
     from ...conf.conf_files import RunConf
     frequencies = np.logspace(10., 16., 8)
     conf = RunConf()
-    conf.compute_isrf(True, frequencies=frequencies)
+    conf.set_specific_energy_nu_frequencies(frequencies)
     with h5py.File(tmpdir.join('conf.h5').strpath, 'w') as f:
-        conf._write_isrf(f)
+        conf._write_specific_energy_nu_frequencies(f)
         conf2 = RunConf()
-        conf2._read_isrf(f)
-    assert conf2.isrf
-    np.testing.assert_allclose(conf2.isrf_frequencies, frequencies)
+        conf2._read_specific_energy_nu_frequencies(f)
+    np.testing.assert_allclose(conf2.specific_energy_nu_frequencies, frequencies)
 
 
-def test_isrf_frequencies_validation():
+def test_specific_energy_nu_frequencies_validation():
     from ...conf.conf_files import RunConf
     conf = RunConf()
     with pytest.raises(ValueError):
-        conf.compute_isrf(True, frequencies=[[1.e10, 1.e12], [1.e14, 1.e16]])
+        conf.set_specific_energy_nu_frequencies([[1.e10, 1.e12], [1.e14, 1.e16]])
     with pytest.raises(ValueError):
-        conf.compute_isrf(True, frequencies=[1.e10, -1.e12])
-    # Default (no custom grid) leaves isrf_frequencies unset
-    conf.compute_isrf(True)
-    assert conf.isrf_frequencies is None
+        conf.set_specific_energy_nu_frequencies([1.e10, -1.e12])
+    # Default: no custom grid set
+    assert conf.specific_energy_nu_frequencies is None
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_isrf_voronoi(tmpdir):
-    # The ISRF must also work on (unstructured) Voronoi grids, where cells are a
-    # flat list rather than a structured grid.
+def test_specific_energy_nu_voronoi(tmpdir):
+    # specific_energy_nu must also work on (unstructured) Voronoi grids, where
+    # cells are a flat list rather than a structured grid.
     rng = np.random.RandomState(12345)
     n = 30
     x = rng.uniform(-1., 1., n)
@@ -206,23 +205,23 @@ def test_isrf_voronoi(tmpdir):
     m.set_n_photons(initial=100000, imaging=0)
     m.set_seed(-12345)
     m.conf.output.output_specific_energy = 'last'
-    m.compute_isrf(True)
+    m.conf.output.output_specific_energy_nu = 'last'
     m.write(tmpdir.join(random_id()).strpath)
     out = m.run(tmpdir.join(random_id()).strpath)
-    _assert_isrf_reconstructs_specific_energy(out.filename)
+    _assert_nu_sums_to_specific_energy(out.filename)
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_isrf_get_quantities(tmpdir):
+def test_specific_energy_nu_get_quantities(tmpdir):
     # specific_energy_nu should be retrievable through get_quantities, the
-    # per-frequency ISRF_frequency_bins metadata should not pollute the grid
-    # quantities, and the retrieved array should still conserve energy.
-    m = _cartesian_isrf_model(True, density=1.e-16)
+    # per-frequency frequencies metadata should not pollute the grid quantities,
+    # and the retrieved array should still conserve energy.
+    m = _cartesian_model('last', density=1.e-16)
     m.write(tmpdir.join(random_id()).strpath)
     out = m.run(tmpdir.join(random_id()).strpath)
     g = out.get_quantities()
     assert 'specific_energy_nu' in g.quantities
-    assert 'ISRF_frequency_bins' not in g.quantities
+    assert 'specific_energy_nu_frequencies' not in g.quantities
     se = np.array(g.quantities['specific_energy'])       # (dust, nz, ny, nx)
     se_nu = np.array(g.quantities['specific_energy_nu'])  # (nu, dust, nz, ny, nx)
     assert se_nu.shape[0] == 2  # number of dust frequencies
@@ -232,12 +231,12 @@ def test_isrf_get_quantities(tmpdir):
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_isrf_yt_export_skips_frequency_resolved(tmpdir):
+def test_specific_energy_nu_yt_export_skips_frequency_resolved(tmpdir):
     # The frequency-resolved specific_energy_nu is not a per-cell scalar, so it
     # must be skipped (not exported as a malformed field) when converting to yt,
     # while the ordinary scalar quantities are still exported.
     pytest.importorskip("yt")
-    m = _cartesian_isrf_model(True, density=1.e-16)
+    m = _cartesian_model('last', density=1.e-16)
     m.write(tmpdir.join(random_id()).strpath)
     out = m.run(tmpdir.join(random_id()).strpath)
     g = out.get_quantities()
@@ -249,14 +248,14 @@ def test_isrf_yt_export_skips_frequency_resolved(tmpdir):
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_isrf_mpi_matches_serial(tmpdir):
-    # The saved ISRF must not depend on the number of MPI processes. We compare
-    # the total ISRF energy (which is conserved, hence robust to Monte Carlo
-    # noise) between a serial run and a 2-process MPI run.
+def test_specific_energy_nu_mpi_matches_serial(tmpdir):
+    # The saved spectrum must not depend on the number of MPI processes. We
+    # compare the total (which is conserved, hence robust to Monte Carlo noise)
+    # between a serial run and a 2-process MPI run.
     if shutil.which('mpirun') is None and shutil.which('mpiexec') is None:
         pytest.skip("no MPI launcher available")
 
-    m = _cartesian_isrf_model(True, n_photons=200000)
+    m = _cartesian_model('last', n_photons=200000)
     m.write(tmpdir.join(random_id()).strpath)
 
     out_serial = m.run(tmpdir.join(random_id()).strpath)

--- a/hyperion/model/tests/test_specific_energy_spectrum.py
+++ b/hyperion/model/tests/test_specific_energy_spectrum.py
@@ -251,9 +251,13 @@ def test_specific_energy_spectrum_yt_export_skips_frequency_resolved(tmpdir):
 def test_specific_energy_spectrum_mpi_matches_serial(tmpdir):
     # The saved spectrum must not depend on the number of MPI processes. We
     # compare the total (which is conserved, hence robust to Monte Carlo noise)
-    # between a serial run and a 2-process MPI run.
+    # between a serial run and a 2-process MPI run. This is skipped unless both an
+    # MPI launcher and the MPI build of the binary are available (e.g. CI only
+    # builds the serial binaries).
     if shutil.which('mpirun') is None and shutil.which('mpiexec') is None:
         pytest.skip("no MPI launcher available")
+    if shutil.which('hyperion_car_mpi') is None:
+        pytest.skip("MPI build of the Hyperion binaries not available")
 
     m = _cartesian_model('last', n_photons=200000)
     m.write(tmpdir.join(random_id()).strpath)

--- a/hyperion/model/tests/test_specific_energy_spectrum.py
+++ b/hyperion/model/tests/test_specific_energy_spectrum.py
@@ -25,13 +25,13 @@ def _read_dataset(filename, suffix):
         return np.asarray(f[matches[-1]][()], dtype=float)
 
 
-def _assert_nu_sums_to_specific_energy(filename):
-    # Summed over frequency, specific_energy_nu must reproduce specific_energy.
+def _assert_spectrum_sums_to_specific_energy(filename):
+    # Summed over frequency, specific_energy_spectrum must reproduce specific_energy.
     # Cells with no absorption are clamped up to the minimum specific energy
-    # (which only affects specific_energy, not the unclamped specific_energy_nu),
+    # (which only affects specific_energy, not the unclamped specific_energy_spectrum),
     # so we compare only cells that were genuinely heated above that floor.
     se = _read_dataset(filename, '/specific_energy')
-    se_nu = _read_dataset(filename, '/specific_energy_nu')
+    se_nu = _read_dataset(filename, '/specific_energy_spectrum')
     assert se_nu is not None
     nu_sum = se_nu.sum(axis=0)
     floor = se.min()
@@ -40,7 +40,7 @@ def _assert_nu_sums_to_specific_energy(filename):
     np.testing.assert_allclose(nu_sum[heated], se[heated], rtol=1.e-6)
 
 
-def _cartesian_model(output_specific_energy_nu='last', n_cells=2, n_photons=100000,
+def _cartesian_model(output_specific_energy_spectrum='last', n_cells=2, n_photons=100000,
                      density=1.e-18, frequencies=None):
     m = Model()
     edges = np.linspace(-1., 1., n_cells + 1)
@@ -54,20 +54,20 @@ def _cartesian_model(output_specific_energy_nu='last', n_cells=2, n_photons=1000
     m.set_n_photons(initial=n_photons, imaging=0)
     m.set_seed(-12345)
     m.conf.output.output_specific_energy = 'last'
-    m.conf.output.output_specific_energy_nu = output_specific_energy_nu
+    m.conf.output.output_specific_energy_spectrum = output_specific_energy_spectrum
     if frequencies is not None:
-        m.set_specific_energy_nu_frequencies(frequencies)
+        m.set_specific_energy_spectrum_frequencies(frequencies)
     return m
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_specific_energy_nu_does_not_change_specific_energy(tmpdir):
+def test_specific_energy_spectrum_does_not_change_specific_energy(tmpdir):
     # Computing the frequency-resolved specific energy must not perturb the
     # ordinary specific-energy (temperature) calculation. This guards against the
     # regression where specific_energy_sum accumulation was gated on the option.
     se = {}
     for output in ('none', 'last'):
-        m = _cartesian_model(output_specific_energy_nu=output)
+        m = _cartesian_model(output_specific_energy_spectrum=output)
         m.write(tmpdir.join(random_id()).strpath)
         out = m.run(tmpdir.join(random_id()).strpath)
         se[output] = _read_dataset(out.filename, '/specific_energy')
@@ -77,29 +77,29 @@ def test_specific_energy_nu_does_not_change_specific_energy(tmpdir):
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_specific_energy_nu_sums_to_specific_energy(tmpdir):
-    # specific_energy_nu, summed over frequency, must reproduce specific_energy.
+def test_specific_energy_spectrum_sums_to_specific_energy(tmpdir):
+    # specific_energy_spectrum, summed over frequency, must reproduce specific_energy.
     m = _cartesian_model('last')
     m.write(tmpdir.join(random_id()).strpath)
     out = m.run(tmpdir.join(random_id()).strpath)
-    _assert_nu_sums_to_specific_energy(out.filename)
+    _assert_spectrum_sums_to_specific_energy(out.filename)
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_specific_energy_nu_frequencies_written(tmpdir):
-    # specific_energy_nu_frequencies is a per-frequency (1-D) quantity, not
+def test_specific_energy_spectrum_frequencies_written(tmpdir):
+    # specific_energy_spectrum_frequencies is a per-frequency (1-D) quantity, not
     # per-cell. This guards against the regression where it was written as a grid
     # array, which segfaulted whenever n_nu was smaller than n_cells.
     m = _cartesian_model('last', n_cells=8)  # 512 cells, dust has 2 frequencies
     m.write(tmpdir.join(random_id()).strpath)
     out = m.run(tmpdir.join(random_id()).strpath)
-    bins = _read_dataset(out.filename, '/specific_energy_nu_frequencies')
+    bins = _read_dataset(out.filename, '/specific_energy_spectrum_frequencies')
     assert bins is not None
     assert bins.shape == (2,)  # == number of dust frequencies, not n_cells
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_specific_energy_nu_dustless_model_runs(tmpdir):
+def test_specific_energy_spectrum_dustless_model_runs(tmpdir):
     # A model with no dust must still run (and image) without crashing. This
     # guards against the regression where the instrumentation dereferenced the
     # first dust type unconditionally, segfaulting dustless models.
@@ -119,8 +119,8 @@ def test_specific_energy_nu_dustless_model_runs(tmpdir):
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_specific_energy_nu_amr(tmpdir):
-    # specific_energy_nu must work on AMR grids: it should run and, summed over
+def test_specific_energy_spectrum_amr(tmpdir):
+    # specific_energy_spectrum must work on AMR grids: it should run and, summed over
     # frequency, reproduce specific_energy in every cell.
     m = Model()
     amr = AMRGrid()
@@ -140,14 +140,14 @@ def test_specific_energy_nu_amr(tmpdir):
     m.set_n_photons(initial=100000, imaging=0)
     m.set_seed(-9)
     m.conf.output.output_specific_energy = 'last'
-    m.conf.output.output_specific_energy_nu = 'last'
+    m.conf.output.output_specific_energy_spectrum = 'last'
     m.write(tmpdir.join(random_id()).strpath)
     out = m.run(tmpdir.join(random_id()).strpath)
-    _assert_nu_sums_to_specific_energy(out.filename)
+    _assert_spectrum_sums_to_specific_energy(out.filename)
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_specific_energy_nu_custom_frequency_grid(tmpdir):
+def test_specific_energy_spectrum_custom_frequency_grid(tmpdir):
     # A user-specified frequency grid (independent of the dust frequency grid)
     # should be used for the output bins, and energy must still be conserved
     # when summing over frequency.
@@ -155,40 +155,40 @@ def test_specific_energy_nu_custom_frequency_grid(tmpdir):
     m = _cartesian_model('last', density=1.e-16, frequencies=frequencies)
     m.write(tmpdir.join(random_id()).strpath)
     out = m.run(tmpdir.join(random_id()).strpath)
-    bins = _read_dataset(out.filename, '/specific_energy_nu_frequencies')
+    bins = _read_dataset(out.filename, '/specific_energy_spectrum_frequencies')
     np.testing.assert_allclose(bins, frequencies, rtol=1.e-6)
-    se_nu = _read_dataset(out.filename, '/specific_energy_nu')
+    se_nu = _read_dataset(out.filename, '/specific_energy_spectrum')
     assert se_nu.shape[0] == len(frequencies)
-    _assert_nu_sums_to_specific_energy(out.filename)
+    _assert_spectrum_sums_to_specific_energy(out.filename)
 
 
-def test_specific_energy_nu_frequencies_roundtrip(tmpdir):
+def test_specific_energy_spectrum_frequencies_roundtrip(tmpdir):
     # The custom frequency grid should survive a write/read round-trip.
     from ...conf.conf_files import RunConf
     frequencies = np.logspace(10., 16., 8)
     conf = RunConf()
-    conf.set_specific_energy_nu_frequencies(frequencies)
+    conf.set_specific_energy_spectrum_frequencies(frequencies)
     with h5py.File(tmpdir.join('conf.h5').strpath, 'w') as f:
-        conf._write_specific_energy_nu_frequencies(f)
+        conf._write_specific_energy_spectrum_frequencies(f)
         conf2 = RunConf()
-        conf2._read_specific_energy_nu_frequencies(f)
-    np.testing.assert_allclose(conf2.specific_energy_nu_frequencies, frequencies)
+        conf2._read_specific_energy_spectrum_frequencies(f)
+    np.testing.assert_allclose(conf2.specific_energy_spectrum_frequencies, frequencies)
 
 
-def test_specific_energy_nu_frequencies_validation():
+def test_specific_energy_spectrum_frequencies_validation():
     from ...conf.conf_files import RunConf
     conf = RunConf()
     with pytest.raises(ValueError):
-        conf.set_specific_energy_nu_frequencies([[1.e10, 1.e12], [1.e14, 1.e16]])
+        conf.set_specific_energy_spectrum_frequencies([[1.e10, 1.e12], [1.e14, 1.e16]])
     with pytest.raises(ValueError):
-        conf.set_specific_energy_nu_frequencies([1.e10, -1.e12])
+        conf.set_specific_energy_spectrum_frequencies([1.e10, -1.e12])
     # Default: no custom grid set
-    assert conf.specific_energy_nu_frequencies is None
+    assert conf.specific_energy_spectrum_frequencies is None
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_specific_energy_nu_voronoi(tmpdir):
-    # specific_energy_nu must also work on (unstructured) Voronoi grids, where
+def test_specific_energy_spectrum_voronoi(tmpdir):
+    # specific_energy_spectrum must also work on (unstructured) Voronoi grids, where
     # cells are a flat list rather than a structured grid.
     rng = np.random.RandomState(12345)
     n = 30
@@ -205,25 +205,25 @@ def test_specific_energy_nu_voronoi(tmpdir):
     m.set_n_photons(initial=100000, imaging=0)
     m.set_seed(-12345)
     m.conf.output.output_specific_energy = 'last'
-    m.conf.output.output_specific_energy_nu = 'last'
+    m.conf.output.output_specific_energy_spectrum = 'last'
     m.write(tmpdir.join(random_id()).strpath)
     out = m.run(tmpdir.join(random_id()).strpath)
-    _assert_nu_sums_to_specific_energy(out.filename)
+    _assert_spectrum_sums_to_specific_energy(out.filename)
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_specific_energy_nu_get_quantities(tmpdir):
-    # specific_energy_nu should be retrievable through get_quantities, the
+def test_specific_energy_spectrum_get_quantities(tmpdir):
+    # specific_energy_spectrum should be retrievable through get_quantities, the
     # per-frequency frequencies metadata should not pollute the grid quantities,
     # and the retrieved array should still conserve energy.
     m = _cartesian_model('last', density=1.e-16)
     m.write(tmpdir.join(random_id()).strpath)
     out = m.run(tmpdir.join(random_id()).strpath)
     g = out.get_quantities()
-    assert 'specific_energy_nu' in g.quantities
-    assert 'specific_energy_nu_frequencies' not in g.quantities
+    assert 'specific_energy_spectrum' in g.quantities
+    assert 'specific_energy_spectrum_frequencies' not in g.quantities
     se = np.array(g.quantities['specific_energy'])       # (dust, nz, ny, nx)
-    se_nu = np.array(g.quantities['specific_energy_nu'])  # (nu, dust, nz, ny, nx)
+    se_nu = np.array(g.quantities['specific_energy_spectrum'])  # (nu, dust, nz, ny, nx)
     assert se_nu.shape[0] == 2  # number of dust frequencies
     nu_sum = se_nu.sum(axis=0)
     heated = se > se.min() * (1. + 1.e-6)
@@ -231,8 +231,8 @@ def test_specific_energy_nu_get_quantities(tmpdir):
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_specific_energy_nu_yt_export_skips_frequency_resolved(tmpdir):
-    # The frequency-resolved specific_energy_nu is not a per-cell scalar, so it
+def test_specific_energy_spectrum_yt_export_skips_frequency_resolved(tmpdir):
+    # The frequency-resolved specific_energy_spectrum is not a per-cell scalar, so it
     # must be skipped (not exported as a malformed field) when converting to yt,
     # while the ordinary scalar quantities are still exported.
     pytest.importorskip("yt")
@@ -240,15 +240,15 @@ def test_specific_energy_nu_yt_export_skips_frequency_resolved(tmpdir):
     m.write(tmpdir.join(random_id()).strpath)
     out = m.run(tmpdir.join(random_id()).strpath)
     g = out.get_quantities()
-    assert 'specific_energy_nu' in g.quantities
+    assert 'specific_energy_spectrum' in g.quantities
     ds = g.to_yt()
     fields = [str(f) for f in ds.field_list]
-    assert not any('specific_energy_nu' in f for f in fields)
+    assert not any('specific_energy_spectrum' in f for f in fields)
     assert any(f.endswith("'density')") for f in fields)
 
 
 @pytest.mark.requires_hyperion_binaries
-def test_specific_energy_nu_mpi_matches_serial(tmpdir):
+def test_specific_energy_spectrum_mpi_matches_serial(tmpdir):
     # The saved spectrum must not depend on the number of MPI processes. We
     # compare the total (which is conserved, hence robust to Monte Carlo noise)
     # between a serial run and a 2-process MPI run.
@@ -261,6 +261,6 @@ def test_specific_energy_nu_mpi_matches_serial(tmpdir):
     out_serial = m.run(tmpdir.join(random_id()).strpath)
     out_mpi = m.run(tmpdir.join(random_id()).strpath, mpi=True, n_processes=2)
 
-    total_serial = np.nansum(_read_dataset(out_serial.filename, '/specific_energy_nu'))
-    total_mpi = np.nansum(_read_dataset(out_mpi.filename, '/specific_energy_nu'))
+    total_serial = np.nansum(_read_dataset(out_serial.filename, '/specific_energy_spectrum'))
+    total_mpi = np.nansum(_read_dataset(out_mpi.filename, '/specific_energy_spectrum'))
     np.testing.assert_allclose(total_mpi, total_serial, rtol=2.e-2)

--- a/src/grid/grid_generic.f90
+++ b/src/grid/grid_generic.f90
@@ -71,14 +71,14 @@ contains
     n_cells = size(specific_energy_sum_nu, 1)
     n_dust = size(specific_energy_sum_nu, 2)
     n_isrf_lam = size(specific_energy_sum_nu,3)
-    do i=1,n_cells
-       do j=1,n_dust
+    !do i=1,n_cells
+    !   do j=1,n_dust
           !print *, "specific_energy_sum = ",specific_energy_sum(i,j)
-          do k=1,n_isrf_lam
-          print *, "specific_energy_sum_nu = ",specific_energy_sum_nu(i,j,k)
-          end do
-       end do
-    end do
+          !do k=1,n_isrf_lam
+          !print *, "specific_energy_sum_nu = ",specific_energy_sum_nu(i,j,k)
+     !     end do
+     !  end do
+    !end do
     
 
     

--- a/src/grid/grid_generic.f90
+++ b/src/grid/grid_generic.f90
@@ -4,7 +4,7 @@ module grid_generic
   use mpi_hdf5_io, only : mp_create_group
   use mpi_core, only : main_process
 
-  use grid_io, only : write_grid_3d, write_grid_4d
+  use grid_io, only : write_grid_3d, write_grid_4d, write_grid_5d
   use grid_geometry, only : geo
   use grid_physics, only : n_photons, last_photon_id, specific_energy_sum, specific_energy_sum_nu, specific_energy, density, density_original
   use settings, only : output_n_photons, output_specific_energy, output_density, output_density_diff, physics_io_type
@@ -32,6 +32,9 @@ contains
 
     integer(hid_t),intent(in) :: group
     integer,intent(in) :: iter, n_iter
+    !DN CRAZY ADDITION
+    integer :: n_cells, n_dust, n_isrf_lam
+    integer :: i,j,k
 
     if(main_process()) write(*,'(" [output_grid] outputting grid arrays for iteration")')
 
@@ -64,20 +67,36 @@ contains
 
 
     
-    ! ENERGY/PATH LENGTHS
+    ! DN Crazy Additions
+    n_cells = size(specific_energy_sum_nu, 1)
+    n_dust = size(specific_energy_sum_nu, 2)
+    n_isrf_lam = size(specific_energy_sum_nu,3)
+    do i=1,n_cells
+       do j=1,n_dust
+          !print *, "specific_energy_sum = ",specific_energy_sum(i,j)
+          do k=1,n_isrf_lam
+          print *, "specific_energy_sum_nu = ",specific_energy_sum_nu(i,j,k)
+          end do
+       end do
+    end do
+    
+
     
     if(trim(output_specific_energy)=='all' .or. (trim(output_specific_energy)=='last'.and.iter==n_iter)) then
-       if(allocated(specific_energy)) then
+       if(allocated(specific_energy_sum_nu)) then
+          !print *, "shape(specific_energy_sum_nu", shape(specific_energy_sum_nu)
+          !print *, "specific_energy_sum_nu = ",specific_energy_sum_nu
           select case(physics_io_type)
+
           case(sp)
-             call write_grid_4d(group, 'specific_energy_sum_nu', real(specific_energy_sum, sp), geo)
+             call write_grid_5d(group, 'specific_energy_sum_nu', real(specific_energy_sum_nu, sp), geo)
           case(dp)
-             call write_grid_4d(group, 'specific_energy_sum_nu', real(specific_energy_sum, dp), geo)
+             call write_grid_5d(group, 'specific_energy_sum_nu', real(specific_energy_sum_nu, dp), geo)
           case default
              call error("output_grid","unexpected value of physics_io_type (should be sp or dp)")
           end select
        else
-          call warn("output_grid","specific_energy array is not allocated")
+          call warn("output_grid","specific_energy_sum_nu array is not allocated")
        end if
     end if
 

--- a/src/grid/grid_generic.f90
+++ b/src/grid/grid_generic.f90
@@ -6,7 +6,7 @@ module grid_generic
 
   use grid_io, only : write_grid_3d, write_grid_4d
   use grid_geometry, only : geo
-  use grid_physics, only : n_photons, last_photon_id, specific_energy_sum, specific_energy, density, density_original
+  use grid_physics, only : n_photons, last_photon_id, specific_energy_sum, specific_energy_sum_nu, specific_energy, density, density_original
   use settings, only : output_n_photons, output_specific_energy, output_density, output_density_diff, physics_io_type
 
   implicit none
@@ -23,6 +23,7 @@ contains
     if(allocated(n_photons)) n_photons = 0
     if(allocated(last_photon_id)) last_photon_id = 0
     if(allocated(specific_energy_sum)) specific_energy_sum = 0._dp
+    if(allocated(specific_energy_sum_nu)) specific_energy_sum_nu = 0._dp
   end subroutine grid_reset_energy
 
   subroutine output_grid(group, iter, n_iter)
@@ -60,6 +61,27 @@ contains
           call warn("output_grid","specific_energy array is not allocated")
        end if
     end if
+
+
+    
+    ! ENERGY/PATH LENGTHS
+    
+    if(trim(output_specific_energy)=='all' .or. (trim(output_specific_energy)=='last'.and.iter==n_iter)) then
+       if(allocated(specific_energy)) then
+          select case(physics_io_type)
+          case(sp)
+             call write_grid_4d(group, 'specific_energy_sum_nu', real(specific_energy_sum, sp), geo)
+          case(dp)
+             call write_grid_4d(group, 'specific_energy_sum_nu', real(specific_energy_sum, dp), geo)
+          case default
+             call error("output_grid","unexpected value of physics_io_type (should be sp or dp)")
+          end select
+       else
+          call warn("output_grid","specific_energy array is not allocated")
+       end if
+    end if
+
+
 
     ! DENSITY
 

--- a/src/grid/grid_generic.f90
+++ b/src/grid/grid_generic.f90
@@ -93,24 +93,28 @@ contains
        if(trim(output_specific_energy)=='all' .or. (trim(output_specific_energy)=='last'.and.iter==n_iter)) then
           if(allocated(specific_energy_nu)) then
              
-             print *,'[GRID_GENERIC.F90] ENTERING BLOCK FOR WRITING SPECIFIC_ENERGY_NU'
 
-             select case(physics_io_type)
+             if (compute_isrf) then
+                print *,'[GRID_GENERIC.F90] ENTERING BLOCK FOR WRITING SPECIFIC_ENERGY_NU'
                 
-             case(sp)
-                print *,'[GRID_GENERIC.F90] diving into write_grid_5d sp'
-                call write_grid_5d(group, 'specific_energy_nu', real(specific_energy_nu, sp), geo)
+                select case(physics_io_type)
+                   
+                case(sp)
+                   print *,'[GRID_GENERIC.F90] diving into write_grid_5d sp'
+                   call write_grid_5d(group, 'specific_energy_nu', real(specific_energy_nu, sp), geo)
 
-             case(dp)
-                print *,'[GRID_GENERIC.F90] diving into write_grid_5d dp'
-                call write_grid_5d(group, 'specific_energy_nu', real(specific_energy_nu, dp), geo)
-                print *,'[GRID_GENERIC.F90] finished with write_grid_5d dp'
+                case(dp)
+                   print *,'[GRID_GENERIC.F90] diving into write_grid_5d dp'
+                   call write_grid_5d(group, 'specific_energy_nu', real(specific_energy_nu, dp), geo)
+                   print *,'[GRID_GENERIC.F90] finished with write_grid_5d dp'
 
-             case default
-                call error("output_grid","unexpected value of physics_io_type (should be sp or dp)")
-             end select
-          else
-             call warn("output_grid","specific_energy_nu array is not allocated")
+                case default
+                   call error("output_grid","unexpected value of physics_io_type (should be sp or dp)")
+                end select
+             else
+                call warn("output_grid","specific_energy_nu array is not allocated")
+
+             end if
           end if
        end if
        

--- a/src/grid/grid_generic.f90
+++ b/src/grid/grid_generic.f90
@@ -9,7 +9,6 @@ module grid_generic
   use grid_physics, only : n_photons, last_photon_id, specific_energy_sum, specific_energy_sum_nu, specific_energy, density, density_original
   use settings, only : output_n_photons, output_specific_energy, output_density, output_density_diff, physics_io_type, compute_isrf
 
-  !DN Crazy Additions
   use dust_main, only: d
   
 
@@ -36,7 +35,6 @@ contains
 
     integer(hid_t),intent(in) :: group
     integer,intent(in) :: iter, n_iter
-    !DN CRAZY ADDITION
     integer :: n_cells, n_dust, n_isrf_lam
     integer :: i,j,k
     real, dimension(d(1)%n_nu) :: energy_frequency_bins
@@ -72,7 +70,6 @@ contains
 
 
     
-    ! DN Crazy Additions
     ! WRITE THE ISRF
     if (compute_isrf) then 
        

--- a/src/grid/grid_generic.f90
+++ b/src/grid/grid_generic.f90
@@ -1,7 +1,7 @@
 module grid_generic
 
   use core_lib, only : sp, dp, hid_t, warn, error
-  use mpi_hdf5_io, only : mp_create_group
+  use mpi_hdf5_io, only : mp_create_group, mp_write_array
   use mpi_core, only : main_process
   
   use grid_io, only : write_grid_3d, write_grid_4d, write_grid_5d
@@ -35,9 +35,8 @@ contains
 
     integer(hid_t),intent(in) :: group
     integer,intent(in) :: iter, n_iter
-    integer :: n_cells, n_dust, n_isrf_lam
-    integer :: i,j,k
-    real, dimension(d(1)%n_nu) :: energy_frequency_bins
+    integer :: i
+    real, allocatable :: energy_frequency_bins(:)
 
 
     if(main_process()) write(*,'(" [output_grid] outputting grid arrays for iteration")')
@@ -72,52 +71,34 @@ contains
 
     
     ! WRITE THE ISRF
-    if (compute_isrf) then 
-       
-       n_cells = size(specific_energy_nu, 1)
-       n_dust = size(specific_energy_nu, 2)
-       n_isrf_lam = size(specific_energy_nu,3)
-       
-       do i=1,d(1)%n_nu
-          energy_frequency_bins(i) = d(1)%nu(i)
-       end do
-       
+    if (compute_isrf) then
+
        if(trim(output_specific_energy)=='all' .or. (trim(output_specific_energy)=='last'.and.iter==n_iter)) then
-          !if(allocated(energy_frequency_bins)) then
-          call write_grid_3d(group, 'ISRF_frequency_bins',energy_frequency_bins, geo)
-          !else
-          !call warn("output_grid","energy_frequency bins [ISRF wavelengths] array is not allocated")
-          !end if
-       end if
-       
-       if(trim(output_specific_energy)=='all' .or. (trim(output_specific_energy)=='last'.and.iter==n_iter)) then
+
+          ! ISRF frequency bins are a per-frequency quantity, not per-cell, so
+          ! they are written as a plain 1-D dataset rather than a grid array.
+          allocate(energy_frequency_bins(d(1)%n_nu))
+          do i=1,d(1)%n_nu
+             energy_frequency_bins(i) = d(1)%nu(i)
+          end do
+          call mp_write_array(group, 'ISRF_frequency_bins', energy_frequency_bins)
+          deallocate(energy_frequency_bins)
+
           if(allocated(specific_energy_nu)) then
-             
-
-             if (compute_isrf) then
-                print *,'[GRID_GENERIC.F90] ENTERING BLOCK FOR WRITING SPECIFIC_ENERGY_NU'
-                
-                select case(physics_io_type)
-                   
-                case(sp)
-                   print *,'[GRID_GENERIC.F90] diving into write_grid_5d sp'
-                   call write_grid_5d(group, 'specific_energy_nu', real(specific_energy_nu, sp), geo)
-
-                case(dp)
-                   print *,'[GRID_GENERIC.F90] diving into write_grid_5d dp'
-                   call write_grid_5d(group, 'specific_energy_nu', real(specific_energy_nu, dp), geo)
-                   print *,'[GRID_GENERIC.F90] finished with write_grid_5d dp'
-
-                case default
-                   call error("output_grid","unexpected value of physics_io_type (should be sp or dp)")
-                end select
-             else
-                call warn("output_grid","specific_energy_nu array is not allocated")
-
-             end if
+             select case(physics_io_type)
+             case(sp)
+                call write_grid_5d(group, 'specific_energy_nu', real(specific_energy_nu, sp), geo)
+             case(dp)
+                call write_grid_5d(group, 'specific_energy_nu', real(specific_energy_nu, dp), geo)
+             case default
+                call error("output_grid","unexpected value of physics_io_type (should be sp or dp)")
+             end select
+          else
+             call warn("output_grid","specific_energy_nu array is not allocated")
           end if
+
        end if
-       
+
     endif
 
 

--- a/src/grid/grid_generic.f90
+++ b/src/grid/grid_generic.f90
@@ -6,8 +6,8 @@ module grid_generic
   
   use grid_io, only : write_grid_3d, write_grid_4d, write_grid_5d
   use grid_geometry, only : geo
-  use grid_physics, only : n_photons, last_photon_id, specific_energy_sum, specific_energy_sum_nu, specific_energy, specific_energy_nu, nu_bins, density, density_original
-  use settings, only : output_n_photons, output_specific_energy, output_specific_energy_nu, output_density, output_density_diff, physics_io_type, compute_specific_energy_nu
+  use grid_physics, only : n_photons, last_photon_id, specific_energy_sum, specific_energy_sum_spectrum, specific_energy, specific_energy_spectrum, nu_bins, density, density_original
+  use settings, only : output_n_photons, output_specific_energy, output_specific_energy_spectrum, output_density, output_density_diff, physics_io_type, compute_specific_energy_spectrum
 
   implicit none
   save
@@ -23,7 +23,7 @@ contains
     if(allocated(n_photons)) n_photons = 0
     if(allocated(last_photon_id)) last_photon_id = 0
     if(allocated(specific_energy_sum)) specific_energy_sum = 0._dp
-    if(allocated(specific_energy_sum_nu)) specific_energy_sum_nu = 0._dp
+    if(allocated(specific_energy_sum_spectrum)) specific_energy_sum_spectrum = 0._dp
   end subroutine grid_reset_energy
 
   subroutine output_grid(group, iter, n_iter)
@@ -65,25 +65,25 @@ contains
 
     
     ! WRITE THE FREQUENCY-RESOLVED SPECIFIC ENERGY
-    if (compute_specific_energy_nu) then
+    if (compute_specific_energy_spectrum) then
 
-       if(trim(output_specific_energy_nu)=='all' .or. (trim(output_specific_energy_nu)=='last'.and.iter==n_iter)) then
+       if(trim(output_specific_energy_spectrum)=='all' .or. (trim(output_specific_energy_spectrum)=='last'.and.iter==n_iter)) then
 
           ! The frequencies are a per-frequency quantity, not per-cell, so they
           ! are written as a plain 1-D dataset rather than a grid array.
-          call mp_write_array(group, 'specific_energy_nu_frequencies', nu_bins)
+          call mp_write_array(group, 'specific_energy_spectrum_frequencies', nu_bins)
 
-          if(allocated(specific_energy_nu)) then
+          if(allocated(specific_energy_spectrum)) then
              select case(physics_io_type)
              case(sp)
-                call write_grid_5d(group, 'specific_energy_nu', real(specific_energy_nu, sp), geo)
+                call write_grid_5d(group, 'specific_energy_spectrum', real(specific_energy_spectrum, sp), geo)
              case(dp)
-                call write_grid_5d(group, 'specific_energy_nu', real(specific_energy_nu, dp), geo)
+                call write_grid_5d(group, 'specific_energy_spectrum', real(specific_energy_spectrum, dp), geo)
              case default
                 call error("output_grid","unexpected value of physics_io_type (should be sp or dp)")
              end select
           else
-             call warn("output_grid","specific_energy_nu array is not allocated")
+             call warn("output_grid","specific_energy_spectrum array is not allocated")
           end if
 
        end if

--- a/src/grid/grid_generic.f90
+++ b/src/grid/grid_generic.f90
@@ -6,8 +6,8 @@ module grid_generic
   
   use grid_io, only : write_grid_3d, write_grid_4d, write_grid_5d
   use grid_geometry, only : geo
-  use grid_physics, only : n_photons, last_photon_id, specific_energy_sum, specific_energy_sum_nu, specific_energy, specific_energy_nu, isrf_nu, density, density_original
-  use settings, only : output_n_photons, output_specific_energy, output_density, output_density_diff, physics_io_type, compute_isrf
+  use grid_physics, only : n_photons, last_photon_id, specific_energy_sum, specific_energy_sum_nu, specific_energy, specific_energy_nu, nu_bins, density, density_original
+  use settings, only : output_n_photons, output_specific_energy, output_specific_energy_nu, output_density, output_density_diff, physics_io_type, compute_specific_energy_nu
 
   implicit none
   save
@@ -64,14 +64,14 @@ contains
 
 
     
-    ! WRITE THE ISRF
-    if (compute_isrf) then
+    ! WRITE THE FREQUENCY-RESOLVED SPECIFIC ENERGY
+    if (compute_specific_energy_nu) then
 
-       if(trim(output_specific_energy)=='all' .or. (trim(output_specific_energy)=='last'.and.iter==n_iter)) then
+       if(trim(output_specific_energy_nu)=='all' .or. (trim(output_specific_energy_nu)=='last'.and.iter==n_iter)) then
 
-          ! ISRF frequency bins are a per-frequency quantity, not per-cell, so
-          ! they are written as a plain 1-D dataset rather than a grid array.
-          call mp_write_array(group, 'ISRF_frequency_bins', isrf_nu)
+          ! The frequencies are a per-frequency quantity, not per-cell, so they
+          ! are written as a plain 1-D dataset rather than a grid array.
+          call mp_write_array(group, 'specific_energy_nu_frequencies', nu_bins)
 
           if(allocated(specific_energy_nu)) then
              select case(physics_io_type)

--- a/src/grid/grid_generic.f90
+++ b/src/grid/grid_generic.f90
@@ -6,11 +6,8 @@ module grid_generic
   
   use grid_io, only : write_grid_3d, write_grid_4d, write_grid_5d
   use grid_geometry, only : geo
-  use grid_physics, only : n_photons, last_photon_id, specific_energy_sum, specific_energy_sum_nu, specific_energy, specific_energy_nu, density, density_original
+  use grid_physics, only : n_photons, last_photon_id, specific_energy_sum, specific_energy_sum_nu, specific_energy, specific_energy_nu, isrf_nu, density, density_original
   use settings, only : output_n_photons, output_specific_energy, output_density, output_density_diff, physics_io_type, compute_isrf
-
-  use dust_main, only: d
-  
 
   implicit none
   save
@@ -35,9 +32,6 @@ contains
 
     integer(hid_t),intent(in) :: group
     integer,intent(in) :: iter, n_iter
-    integer :: i
-    real, allocatable :: energy_frequency_bins(:)
-
 
     if(main_process()) write(*,'(" [output_grid] outputting grid arrays for iteration")')
 
@@ -77,12 +71,7 @@ contains
 
           ! ISRF frequency bins are a per-frequency quantity, not per-cell, so
           ! they are written as a plain 1-D dataset rather than a grid array.
-          allocate(energy_frequency_bins(d(1)%n_nu))
-          do i=1,d(1)%n_nu
-             energy_frequency_bins(i) = d(1)%nu(i)
-          end do
-          call mp_write_array(group, 'ISRF_frequency_bins', energy_frequency_bins)
-          deallocate(energy_frequency_bins)
+          call mp_write_array(group, 'ISRF_frequency_bins', isrf_nu)
 
           if(allocated(specific_energy_nu)) then
              select case(physics_io_type)

--- a/src/grid/grid_io.f90
+++ b/src/grid/grid_io.f90
@@ -163,10 +163,12 @@ contains
 
     implicit none
 
+
     integer(hid_t), intent(in) :: group
     character(len=*), intent(in) :: path
     integer(idp), intent(in) :: array(:,:,:)
     type(grid_geometry_desc),intent(in) :: geo
+
 
     call mp_write_array(group, path, reshape(array, (/geo%n1, geo%n2, geo%n3, size(array,2), size(array,3)/)))
     call mp_write_keyword(group, path, 'geometry', geo%id)
@@ -433,6 +435,7 @@ contains
     character(len=*), intent(in) :: path
     real(dp), intent(in) :: array(:,:,:)
     type(grid_geometry_desc),intent(in) :: geo
+
 
     call mp_write_array(group, path, reshape(array, (/geo%n1, geo%n2, geo%n3, size(array,2), size(array,3)/)))
     call mp_write_keyword(group, path, 'geometry', geo%id)

--- a/src/grid/grid_io.f90
+++ b/src/grid/grid_io.f90
@@ -12,7 +12,6 @@ module grid_io
   public :: grid_exists
   public :: read_grid_3d
   public :: read_grid_4d
-  public :: read_grid_5d
   public :: write_grid_3d
   public :: write_grid_4d
   public :: write_grid_5d
@@ -30,14 +29,6 @@ module grid_io
      module procedure read_grid_4d_int
      module procedure read_grid_4d_int8
   end interface read_grid_4d
-
-  interface read_grid_5d
-     module procedure read_grid_5d_sp
-     module procedure read_grid_5d_dp
-     module procedure read_grid_5d_int
-     module procedure read_grid_5d_int8
-  end interface read_grid_5d
-
 
   interface write_grid_3d
      module procedure write_grid_3d_sp
@@ -69,36 +60,6 @@ contains
     character(len=*),intent(in) :: name
     grid_exists = mp_path_exists(group, name)
   end function grid_exists
-
-
-  subroutine read_grid_5d_int8(group, path, array, geo)
-    
-    implicit none
-    
-    integer(hid_t), intent(in) :: group
-    character(len=*), intent(in) :: path
-    integer(idp), intent(out) :: array(:,:,:)
-    type(grid_geometry_desc),intent(in) :: geo
-    integer(idp), allocatable :: array5d(:,:,:,:,:)
-    integer :: n_cells, n_dust, n_isrf_lam
-
-    character(len=32) :: geometry_id_check
-
-    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
-    if(geometry_id_check.ne.geo%id) then
-       call error("read_grid", "geometry IDs do not match")
-    end if
-    call mp_read_array_auto(group,path, array5d)
-
-    if(any(is_nan(array5d))) call error("read_grid_5d", "NaN values in 5D array")
-
-    n_cells = size(array, 1)
-    n_dust = size(array, 2)
-    n_isrf_lam = size(array,3)
-
-    array = reshape(array5d, (/n_cells, n_dust, n_isrf_lam/))
-
-  end subroutine read_grid_5d_int8
 
 
   subroutine read_grid_4d_int8(group, path, array, geo)
@@ -207,37 +168,6 @@ contains
   end subroutine write_grid_3d_int8
 
 
-  subroutine read_grid_5d_int(group, path, array, geo)
-
-    implicit none
-
-    integer(hid_t), intent(in) :: group
-    character(len=*), intent(in) :: path
-    integer, intent(out) :: array(:,:,:)
-    type(grid_geometry_desc),intent(in) :: geo
-    integer, allocatable :: array5d(:,:,:,:,:)
-    integer :: n_cells, n_dust, n_isrf_lam
-
-    character(len=32) :: geometry_id_check
-
-    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
-    if(geometry_id_check.ne.geo%id) then
-       call error("read_grid", "geometry IDs do not match")
-    end if
-    call mp_read_array_auto(group,path, array5d)
-
-    if(any(is_nan(array5d))) call error("read_grid_5d", "NaN values in 5D array")
-
-    n_cells = size(array, 1)
-    n_dust = size(array, 2)
-    n_isrf_lam = size(array,3)
-
-    array = reshape(array5d, (/n_cells, n_dust, n_isrf_lam/))
-
-  end subroutine read_grid_5d_int
-
-
-
   subroutine read_grid_4d_int(group, path, array, geo)
 
     implicit none
@@ -340,36 +270,6 @@ contains
   end subroutine write_grid_3d_int
 
 
-  subroutine read_grid_5d_dp(group, path, array, geo)
-
-    implicit none
-
-    integer(hid_t), intent(in) :: group
-    character(len=*), intent(in) :: path
-    real(dp), intent(out) :: array(:,:,:)
-    type(grid_geometry_desc),intent(in) :: geo
-    real(dp), allocatable :: array5d(:,:,:,:,:)
-    integer :: n_cells, n_dust, n_isrf_lam
-
-    character(len=32) :: geometry_id_check
-
-    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
-    if(geometry_id_check.ne.geo%id) then
-       call error("read_grid", "geometry IDs do not match")
-    end if
-    call mp_read_array_auto(group,path, array5d)
-
-    if(any(is_nan(array5d))) call error("read_grid_5d", "NaN values in 5D array")
-
-    n_cells = size(array, 1)
-    n_dust = size(array, 2)
-    n_isrf_lam = size(array,3)
-
-    array = reshape(array5d, (/n_cells, n_dust, n_isrf_lam/))
-
-  end subroutine read_grid_5d_dp
-
-
   subroutine read_grid_4d_dp(group, path, array, geo)
 
     implicit none
@@ -470,37 +370,6 @@ contains
     call mp_write_keyword(group,path, 'geometry', geo%id)
 
   end subroutine write_grid_3d_dp
-
-
-  !DN CRAZY ADDITIONS
-  subroutine read_grid_5d_sp(group, path, array, geo)
-    
-    implicit none
-    
-    integer(hid_t), intent(in) :: group
-    character(len=*), intent(in) :: path
-    real(sp), intent(out) :: array(:,:,:)
-    type(grid_geometry_desc),intent(in) :: geo
-    real(sp), allocatable :: array5d(:,:,:,:,:)
-    integer :: n_cells, n_dust, n_isrf_lam
-
-    character(len=32) :: geometry_id_check
-
-    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
-    if(geometry_id_check.ne.geo%id) then
-       call error("read_grid", "geometry IDs do not match")
-    end if
-    call mp_read_array_auto(group,path, array5d)
-
-    if(any(is_nan(array5d))) call error("read_grid_5d", "NaN values in 5D array")
-
-    n_cells = size(array, 1)
-    n_dust = size(array, 2)
-    n_isrf_lam = size(array,3)
-
-    array = reshape(array5d, (/n_cells, n_dust, n_isrf_lam/))
-
-  end subroutine read_grid_5d_sp
 
 
   subroutine read_grid_4d_sp(group, path, array, geo)

--- a/src/grid/grid_io.f90
+++ b/src/grid/grid_io.f90
@@ -12,8 +12,10 @@ module grid_io
   public :: grid_exists
   public :: read_grid_3d
   public :: read_grid_4d
+  public :: read_grid_5d
   public :: write_grid_3d
   public :: write_grid_4d
+  public :: write_grid_5d
 
   interface read_grid_3d
      module procedure read_grid_3d_sp
@@ -29,6 +31,14 @@ module grid_io
      module procedure read_grid_4d_int8
   end interface read_grid_4d
 
+  interface read_grid_5d
+     module procedure read_grid_5d_sp
+     module procedure read_grid_5d_dp
+     module procedure read_grid_5d_int
+     module procedure read_grid_5d_int8
+  end interface read_grid_5d
+
+
   interface write_grid_3d
      module procedure write_grid_3d_sp
      module procedure write_grid_3d_dp
@@ -43,6 +53,14 @@ module grid_io
      module procedure write_grid_4d_int8
   end interface write_grid_4d
 
+  interface write_grid_5d
+     module procedure write_grid_5d_sp
+     module procedure write_grid_5d_dp
+     module procedure write_grid_5d_int
+     module procedure write_grid_5d_int8
+  end interface write_grid_5d
+
+
 contains
 
   logical function grid_exists(group, name)
@@ -51,6 +69,36 @@ contains
     character(len=*),intent(in) :: name
     grid_exists = mp_path_exists(group, name)
   end function grid_exists
+
+  !DN CRAZY ADDITIONS
+  subroutine read_grid_5d_int8(group, path, array, geo)
+    
+    implicit none
+    
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    integer(idp), intent(out) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+    integer(idp), allocatable :: array5d(:,:,:,:,:)
+    integer :: n_cells, n_dust, n_isrf_lam
+
+    character(len=32) :: geometry_id_check
+
+    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
+    if(geometry_id_check.ne.geo%id) then
+       call error("read_grid", "geometry IDs do not match")
+    end if
+    call mp_read_array_auto(group,path, array5d)
+
+    if(any(is_nan(array5d))) call error("read_grid_5d", "NaN values in 5D array")
+
+    n_cells = size(array, 1)
+    n_dust = size(array, 2)
+    n_isrf_lam = size(array,3)
+
+    array = reshape(array5d, (/n_cells, n_dust, n_isrf_lam/))
+
+  end subroutine read_grid_5d_int8
 
 
   subroutine read_grid_4d_int8(group, path, array, geo)
@@ -108,6 +156,26 @@ contains
 
   end subroutine read_grid_3d_int8
 
+
+
+  !DN CRAZY ADDITIONS
+  subroutine write_grid_5d_int8(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    integer(idp), intent(in) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+
+    call mp_write_array(group, path, reshape(array, (/geo%n1, geo%n2, geo%n3, size(array,2), size(array,3)/)))
+    call mp_write_keyword(group, path, 'geometry', geo%id)
+
+  end subroutine write_grid_5d_int8
+
+
+
+
   subroutine write_grid_4d_int8(group, path, array, geo)
 
     implicit none
@@ -135,6 +203,37 @@ contains
     call mp_write_keyword(group,path, 'geometry', geo%id)
 
   end subroutine write_grid_3d_int8
+
+  !DN CRAZY ADDITIONS
+  subroutine read_grid_5d_int(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    integer, intent(out) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+    integer, allocatable :: array5d(:,:,:,:,:)
+    integer :: n_cells, n_dust, n_isrf_lam
+
+    character(len=32) :: geometry_id_check
+
+    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
+    if(geometry_id_check.ne.geo%id) then
+       call error("read_grid", "geometry IDs do not match")
+    end if
+    call mp_read_array_auto(group,path, array5d)
+
+    if(any(is_nan(array5d))) call error("read_grid_5d", "NaN values in 5D array")
+
+    n_cells = size(array, 1)
+    n_dust = size(array, 2)
+    n_isrf_lam = size(array,3)
+
+    array = reshape(array5d, (/n_cells, n_dust, n_isrf_lam/))
+
+  end subroutine read_grid_5d_int
+
 
 
   subroutine read_grid_4d_int(group, path, array, geo)
@@ -192,6 +291,24 @@ contains
 
   end subroutine read_grid_3d_int
 
+
+  !DN CRAZY ADDITION
+
+  subroutine write_grid_5d_int(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    integer, intent(in) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+
+    call mp_write_array(group, path, reshape(array, (/geo%n1, geo%n2, geo%n3, size(array,2), size(array,3)/)))
+    call mp_write_keyword(group, path, 'geometry', geo%id)
+
+  end subroutine write_grid_5d_int
+
+
   subroutine write_grid_4d_int(group, path, array, geo)
 
     implicit none
@@ -219,6 +336,36 @@ contains
     call mp_write_keyword(group,path, 'geometry', geo%id)
 
   end subroutine write_grid_3d_int
+
+  !DN CRAZY ADDITIONS
+  subroutine read_grid_5d_dp(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    real(dp), intent(out) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+    real(dp), allocatable :: array5d(:,:,:,:,:)
+    integer :: n_cells, n_dust, n_isrf_lam
+
+    character(len=32) :: geometry_id_check
+
+    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
+    if(geometry_id_check.ne.geo%id) then
+       call error("read_grid", "geometry IDs do not match")
+    end if
+    call mp_read_array_auto(group,path, array5d)
+
+    if(any(is_nan(array5d))) call error("read_grid_5d", "NaN values in 5D array")
+
+    n_cells = size(array, 1)
+    n_dust = size(array, 2)
+    n_isrf_lam = size(array,3)
+
+    array = reshape(array5d, (/n_cells, n_dust, n_isrf_lam/))
+
+  end subroutine read_grid_5d_dp
 
 
   subroutine read_grid_4d_dp(group, path, array, geo)
@@ -276,6 +423,23 @@ contains
 
   end subroutine read_grid_3d_dp
 
+
+  !CRAZY DN ADDITIONS
+  subroutine write_grid_5d_dp(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    real(dp), intent(in) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+
+    call mp_write_array(group, path, reshape(array, (/geo%n1, geo%n2, geo%n3, size(array,2), size(array,3)/)))
+    call mp_write_keyword(group, path, 'geometry', geo%id)
+
+  end subroutine write_grid_5d_dp
+
+
   subroutine write_grid_4d_dp(group, path, array, geo)
 
     implicit none
@@ -303,6 +467,37 @@ contains
     call mp_write_keyword(group,path, 'geometry', geo%id)
 
   end subroutine write_grid_3d_dp
+
+
+  !DN CRAZY ADDITIONS
+  subroutine read_grid_5d_sp(group, path, array, geo)
+    
+    implicit none
+    
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    real(sp), intent(out) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+    real(sp), allocatable :: array5d(:,:,:,:,:)
+    integer :: n_cells, n_dust, n_isrf_lam
+
+    character(len=32) :: geometry_id_check
+
+    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
+    if(geometry_id_check.ne.geo%id) then
+       call error("read_grid", "geometry IDs do not match")
+    end if
+    call mp_read_array_auto(group,path, array5d)
+
+    if(any(is_nan(array5d))) call error("read_grid_5d", "NaN values in 5D array")
+
+    n_cells = size(array, 1)
+    n_dust = size(array, 2)
+    n_isrf_lam = size(array,3)
+
+    array = reshape(array5d, (/n_cells, n_dust, n_isrf_lam/))
+
+  end subroutine read_grid_5d_sp
 
 
   subroutine read_grid_4d_sp(group, path, array, geo)
@@ -359,6 +554,23 @@ contains
     array = reshape(array3d, (/n_cells/))
 
   end subroutine read_grid_3d_sp
+
+
+  !CRAZY DN ADDITIONS
+  subroutine write_grid_5d_sp(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    real(sp), intent(in) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+
+    call mp_write_array(group, path, reshape(array, (/geo%n1, geo%n2, geo%n3, size(array,2), size(array,3)/)))
+    call mp_write_keyword(group, path, 'geometry', geo%id)
+
+  end subroutine write_grid_5d_sp
+
 
   subroutine write_grid_4d_sp(group, path, array, geo)
 

--- a/src/grid/grid_io.f90
+++ b/src/grid/grid_io.f90
@@ -70,7 +70,7 @@ contains
     grid_exists = mp_path_exists(group, name)
   end function grid_exists
 
-  !DN CRAZY ADDITIONS
+
   subroutine read_grid_5d_int8(group, path, array, geo)
     
     implicit none
@@ -158,7 +158,7 @@ contains
 
 
 
-  !DN CRAZY ADDITIONS
+
   subroutine write_grid_5d_int8(group, path, array, geo)
 
     implicit none
@@ -204,7 +204,7 @@ contains
 
   end subroutine write_grid_3d_int8
 
-  !DN CRAZY ADDITIONS
+
   subroutine read_grid_5d_int(group, path, array, geo)
 
     implicit none
@@ -292,7 +292,7 @@ contains
   end subroutine read_grid_3d_int
 
 
-  !DN CRAZY ADDITION
+
 
   subroutine write_grid_5d_int(group, path, array, geo)
 
@@ -337,7 +337,7 @@ contains
 
   end subroutine write_grid_3d_int
 
-  !DN CRAZY ADDITIONS
+
   subroutine read_grid_5d_dp(group, path, array, geo)
 
     implicit none
@@ -424,7 +424,7 @@ contains
   end subroutine read_grid_3d_dp
 
 
-  !CRAZY DN ADDITIONS
+
   subroutine write_grid_5d_dp(group, path, array, geo)
 
     implicit none

--- a/src/grid/grid_io.f90
+++ b/src/grid/grid_io.f90
@@ -428,7 +428,6 @@ contains
   end subroutine read_grid_3d_sp
 
 
-  !CRAZY DN ADDITIONS
   subroutine write_grid_5d_sp(group, path, array, geo)
 
     implicit none

--- a/src/grid/grid_io_1d.f90
+++ b/src/grid/grid_io_1d.f90
@@ -12,8 +12,11 @@ module grid_io
   public :: grid_exists
   public :: read_grid_3d
   public :: read_grid_4d
+  public :: read_grid_5d
   public :: write_grid_3d
   public :: write_grid_4d
+  public :: write_grid_5d
+  
 
   interface read_grid_3d
      module procedure read_grid_3d_sp
@@ -29,6 +32,14 @@ module grid_io
      module procedure read_grid_4d_int8
   end interface read_grid_4d
 
+  interface read_grid_5d
+     module procedure read_grid_5d_sp
+     module procedure read_grid_5d_dp
+     module procedure read_grid_5d_int
+     module procedure read_grid_5d_int8
+  end interface read_grid_5d
+
+
   interface write_grid_3d
      module procedure write_grid_3d_sp
      module procedure write_grid_3d_dp
@@ -43,6 +54,14 @@ module grid_io
      module procedure write_grid_4d_int8
   end interface write_grid_4d
 
+  interface write_grid_5d
+     module procedure write_grid_5d_sp
+     module procedure write_grid_5d_dp
+     module procedure write_grid_5d_int
+     module procedure write_grid_5d_int8
+  end interface write_grid_5d
+
+
 contains
 
   logical function grid_exists(group, name)
@@ -51,6 +70,28 @@ contains
     character(len=*),intent(in) :: name
     grid_exists = mp_path_exists(group, name)
   end function grid_exists
+
+  !DN CRAZY ADDITIONS
+  subroutine read_grid_5d_int8(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    integer(idp), intent(out) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+
+    character(len=32) :: geometry_id_check
+
+    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
+    if(geometry_id_check.ne.geo%id) then
+       call error("read_grid", "geometry IDs do not match")
+    end if
+    call mp_read_array(group, path, array)
+
+    if(any(is_nan(array))) call error("read_grid_5d", "NaN values in 5D array")
+
+  end subroutine read_grid_5d_int8
 
 
   subroutine read_grid_4d_int8(group, path, array, geo)
@@ -95,6 +136,23 @@ contains
 
   end subroutine read_grid_3d_int8
 
+
+  !DN CRAZY ADDITIONS
+  subroutine write_grid_5d_int8(group, path, array, geo)
+    
+    implicit none
+    
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    integer(idp), intent(in) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+
+    call mp_write_array(group, path, array)
+    call mp_write_keyword(group, path, 'geometry', geo%id)
+
+  end subroutine write_grid_5d_int8
+
+
   subroutine write_grid_4d_int8(group, path, array, geo)
 
     implicit none
@@ -122,6 +180,28 @@ contains
     call mp_write_keyword(group,path, 'geometry', geo%id)
 
   end subroutine write_grid_3d_int8
+
+  !DN CRAZY ADDITIONS
+  subroutine read_grid_5d_int(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    integer, intent(out) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+
+    character(len=32) :: geometry_id_check
+
+    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
+    if(geometry_id_check.ne.geo%id) then
+       call error("read_grid", "geometry IDs do not match")
+    end if
+    call mp_read_array(group, path, array)
+
+    if(any(is_nan(array))) call error("read_grid_5d", "NaN values in 5D array")
+
+  end subroutine read_grid_5d_int
 
 
   subroutine read_grid_4d_int(group, path, array, geo)
@@ -166,6 +246,25 @@ contains
 
   end subroutine read_grid_3d_int
 
+
+
+    !DN CRAZY ADDITION
+
+  subroutine write_grid_5d_int(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    integer, intent(in) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+
+    call mp_write_array(group, path, array)
+    call mp_write_keyword(group, path, 'geometry', geo%id)
+
+  end subroutine write_grid_5d_int
+
+
   subroutine write_grid_4d_int(group, path, array, geo)
 
     implicit none
@@ -193,6 +292,28 @@ contains
     call mp_write_keyword(group,path, 'geometry', geo%id)
 
   end subroutine write_grid_3d_int
+
+  !DN CRAZY ADDITIONS
+  subroutine read_grid_5d_dp(group, path, array, geo)
+    
+    implicit none
+    
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    real(dp), intent(out) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+
+    character(len=32) :: geometry_id_check
+
+    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
+    if(geometry_id_check.ne.geo%id) then
+       call error("read_grid", "geometry IDs do not match")
+    end if
+    call mp_read_array(group, path, array)
+
+    if(any(is_nan(array))) call error("read_grid_5d", "NaN values in 5D array")
+
+  end subroutine read_grid_5d_dp
 
 
   subroutine read_grid_4d_dp(group, path, array, geo)
@@ -237,6 +358,23 @@ contains
 
   end subroutine read_grid_3d_dp
 
+
+  !CRAZY DN ADDITIONS
+  subroutine write_grid_5d_dp(group, path, array, geo)
+    
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    real(dp), intent(in) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+
+    call mp_write_array(group, path, array)
+    call mp_write_keyword(group, path, 'geometry', geo%id)
+
+  end subroutine write_grid_5d_dp
+
+
   subroutine write_grid_4d_dp(group, path, array, geo)
 
     implicit none
@@ -264,6 +402,29 @@ contains
     call mp_write_keyword(group,path, 'geometry', geo%id)
 
   end subroutine write_grid_3d_dp
+
+  
+  !DN CRAZY ADDITIONS
+  subroutine read_grid_5d_sp(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    real(sp), intent(out) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+
+    character(len=32) :: geometry_id_check
+
+    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
+    if(geometry_id_check.ne.geo%id) then
+       call error("read_grid", "geometry IDs do not match")
+    end if
+    call mp_read_array(group, path, array)
+
+    if(any(is_nan(array))) call error("read_grid_5d", "NaN values in 5D array")
+
+  end subroutine read_grid_5d_sp
 
 
   subroutine read_grid_4d_sp(group, path, array, geo)
@@ -307,6 +468,23 @@ contains
     if(any(is_nan(array))) call error("read_grid_3d", "NaN values in 3D array")
 
   end subroutine read_grid_3d_sp
+
+
+  !CRAZY DN ADDITIONS
+  subroutine write_grid_5d_sp(group, path, array, geo)
+    
+    implicit none
+    
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    real(sp), intent(in) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+    
+    call mp_write_array(group, path, array)
+    call mp_write_keyword(group, path, 'geometry', geo%id)
+    
+  end subroutine write_grid_5d_sp
+
 
   subroutine write_grid_4d_sp(group, path, array, geo)
 

--- a/src/grid/grid_io_1d.f90
+++ b/src/grid/grid_io_1d.f90
@@ -12,7 +12,6 @@ module grid_io
   public :: grid_exists
   public :: read_grid_3d
   public :: read_grid_4d
-  public :: read_grid_5d
   public :: write_grid_3d
   public :: write_grid_4d
   public :: write_grid_5d
@@ -31,14 +30,6 @@ module grid_io
      module procedure read_grid_4d_int
      module procedure read_grid_4d_int8
   end interface read_grid_4d
-
-  interface read_grid_5d
-     module procedure read_grid_5d_sp
-     module procedure read_grid_5d_dp
-     module procedure read_grid_5d_int
-     module procedure read_grid_5d_int8
-  end interface read_grid_5d
-
 
   interface write_grid_3d
      module procedure write_grid_3d_sp
@@ -70,28 +61,6 @@ contains
     character(len=*),intent(in) :: name
     grid_exists = mp_path_exists(group, name)
   end function grid_exists
-
-
-  subroutine read_grid_5d_int8(group, path, array, geo)
-
-    implicit none
-
-    integer(hid_t), intent(in) :: group
-    character(len=*), intent(in) :: path
-    integer(idp), intent(out) :: array(:,:,:)
-    type(grid_geometry_desc),intent(in) :: geo
-
-    character(len=32) :: geometry_id_check
-
-    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
-    if(geometry_id_check.ne.geo%id) then
-       call error("read_grid", "geometry IDs do not match")
-    end if
-    call mp_read_array(group, path, array)
-
-    if(any(is_nan(array))) call error("read_grid_5d", "NaN values in 5D array")
-
-  end subroutine read_grid_5d_int8
 
 
   subroutine read_grid_4d_int8(group, path, array, geo)
@@ -180,28 +149,6 @@ contains
     call mp_write_keyword(group,path, 'geometry', geo%id)
 
   end subroutine write_grid_3d_int8
-
-
-  subroutine read_grid_5d_int(group, path, array, geo)
-
-    implicit none
-
-    integer(hid_t), intent(in) :: group
-    character(len=*), intent(in) :: path
-    integer, intent(out) :: array(:,:,:)
-    type(grid_geometry_desc),intent(in) :: geo
-
-    character(len=32) :: geometry_id_check
-
-    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
-    if(geometry_id_check.ne.geo%id) then
-       call error("read_grid", "geometry IDs do not match")
-    end if
-    call mp_read_array(group, path, array)
-
-    if(any(is_nan(array))) call error("read_grid_5d", "NaN values in 5D array")
-
-  end subroutine read_grid_5d_int
 
 
   subroutine read_grid_4d_int(group, path, array, geo)
@@ -294,28 +241,6 @@ contains
   end subroutine write_grid_3d_int
 
  
-  subroutine read_grid_5d_dp(group, path, array, geo)
-    
-    implicit none
-    
-    integer(hid_t), intent(in) :: group
-    character(len=*), intent(in) :: path
-    real(dp), intent(out) :: array(:,:,:)
-    type(grid_geometry_desc),intent(in) :: geo
-
-    character(len=32) :: geometry_id_check
-
-    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
-    if(geometry_id_check.ne.geo%id) then
-       call error("read_grid", "geometry IDs do not match")
-    end if
-    call mp_read_array(group, path, array)
-
-    if(any(is_nan(array))) call error("read_grid_5d", "NaN values in 5D array")
-
-  end subroutine read_grid_5d_dp
-
-
   subroutine read_grid_4d_dp(group, path, array, geo)
 
     implicit none
@@ -404,29 +329,6 @@ contains
   end subroutine write_grid_3d_dp
 
   
-
-  subroutine read_grid_5d_sp(group, path, array, geo)
-
-    implicit none
-
-    integer(hid_t), intent(in) :: group
-    character(len=*), intent(in) :: path
-    real(sp), intent(out) :: array(:,:,:)
-    type(grid_geometry_desc),intent(in) :: geo
-
-    character(len=32) :: geometry_id_check
-
-    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
-    if(geometry_id_check.ne.geo%id) then
-       call error("read_grid", "geometry IDs do not match")
-    end if
-    call mp_read_array(group, path, array)
-
-    if(any(is_nan(array))) call error("read_grid_5d", "NaN values in 5D array")
-
-  end subroutine read_grid_5d_sp
-
-
   subroutine read_grid_4d_sp(group, path, array, geo)
 
     implicit none

--- a/src/grid/grid_io_1d.f90
+++ b/src/grid/grid_io_1d.f90
@@ -71,7 +71,7 @@ contains
     grid_exists = mp_path_exists(group, name)
   end function grid_exists
 
-  !DN CRAZY ADDITIONS
+
   subroutine read_grid_5d_int8(group, path, array, geo)
 
     implicit none
@@ -137,7 +137,7 @@ contains
   end subroutine read_grid_3d_int8
 
 
-  !DN CRAZY ADDITIONS
+
   subroutine write_grid_5d_int8(group, path, array, geo)
     
     implicit none
@@ -181,7 +181,7 @@ contains
 
   end subroutine write_grid_3d_int8
 
-  !DN CRAZY ADDITIONS
+
   subroutine read_grid_5d_int(group, path, array, geo)
 
     implicit none
@@ -248,7 +248,7 @@ contains
 
 
 
-    !DN CRAZY ADDITION
+
 
   subroutine write_grid_5d_int(group, path, array, geo)
 
@@ -293,7 +293,7 @@ contains
 
   end subroutine write_grid_3d_int
 
-  !DN CRAZY ADDITIONS
+ 
   subroutine read_grid_5d_dp(group, path, array, geo)
     
     implicit none
@@ -359,7 +359,7 @@ contains
   end subroutine read_grid_3d_dp
 
 
-  !CRAZY DN ADDITIONS
+
   subroutine write_grid_5d_dp(group, path, array, geo)
     
     implicit none
@@ -404,7 +404,7 @@ contains
   end subroutine write_grid_3d_dp
 
   
-  !DN CRAZY ADDITIONS
+
   subroutine read_grid_5d_sp(group, path, array, geo)
 
     implicit none
@@ -470,7 +470,7 @@ contains
   end subroutine read_grid_3d_sp
 
 
-  !CRAZY DN ADDITIONS
+
   subroutine write_grid_5d_sp(group, path, array, geo)
     
     implicit none

--- a/src/grid/grid_io_1d_template.f90
+++ b/src/grid/grid_io_1d_template.f90
@@ -11,7 +11,6 @@ module grid_io
   public :: grid_exists
   public :: read_grid_3d
   public :: read_grid_4d
-  public :: read_grid_5d
   public :: write_grid_3d
   public :: write_grid_4d
 
@@ -28,13 +27,6 @@ module grid_io
      module procedure read_grid_4d_int
      module procedure read_grid_4d_int8
   end interface read_grid_4d
-
-  interface read_grid_5d
-     module procedure read_grid_5d_sp
-     module procedure read_grid_5d_dp
-     module procedure read_grid_5d_int
-     module procedure read_grid_5d_int8
-  end interface read_grid_5d
 
   interface write_grid_3d
      module procedure write_grid_3d_sp
@@ -69,28 +61,6 @@ contains
   end function grid_exists
 
   !!@FOR real(sp):sp real(dp):dp integer:int integer(idp):int8
-
-
-  subroutine read_grid_5d_<T>(group, path, array, geo)
-
-    implicit none
-
-    integer(hid_t), intent(in) :: group
-    character(len=*), intent(in) :: path
-    @T, intent(out) :: array(:,:,:)
-    type(grid_geometry_desc),intent(in) :: geo
-
-    character(len=32) :: geometry_id_check
-
-    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
-    if(geometry_id_check.ne.geo%id) then
-       call error("read_grid", "geometry IDs do not match")
-    end if
-    call mp_read_array(group, path, array)
-
-    if(any(is_nan(array))) call error("read_grid_5d", "NaN values in 5D array")
-
-  end subroutine read_grid_5d_<T>
 
 
   subroutine read_grid_4d_<T>(group, path, array, geo)

--- a/src/grid/grid_io_1d_template.f90
+++ b/src/grid/grid_io_1d_template.f90
@@ -11,6 +11,7 @@ module grid_io
   public :: grid_exists
   public :: read_grid_3d
   public :: read_grid_4d
+  public :: read_grid_5d
   public :: write_grid_3d
   public :: write_grid_4d
 
@@ -28,6 +29,13 @@ module grid_io
      module procedure read_grid_4d_int8
   end interface read_grid_4d
 
+  interface read_grid_5d
+     module procedure read_grid_5d_sp
+     module procedure read_grid_5d_dp
+     module procedure read_grid_5d_int
+     module procedure read_grid_5d_int8
+  end interface read_grid_5d
+
   interface write_grid_3d
      module procedure write_grid_3d_sp
      module procedure write_grid_3d_dp
@@ -41,6 +49,15 @@ module grid_io
      module procedure write_grid_4d_int
      module procedure write_grid_4d_int8
   end interface write_grid_4d
+  
+  interface write_grid_5d
+     module procedure write_grid_5d_sp
+     module procedure write_grid_5d_dp
+     module procedure write_grid_5d_int
+     module procedure write_grid_5d_int8
+  end interface write_grid_5d
+
+
 
 contains
 
@@ -52,6 +69,29 @@ contains
   end function grid_exists
 
   !!@FOR real(sp):sp real(dp):dp integer:int integer(idp):int8
+
+
+  subroutine read_grid_5d_<T>(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    @T, intent(out) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+
+    character(len=32) :: geometry_id_check
+
+    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
+    if(geometry_id_check.ne.geo%id) then
+       call error("read_grid", "geometry IDs do not match")
+    end if
+    call mp_read_array(group, path, array)
+
+    if(any(is_nan(array))) call error("read_grid_5d", "NaN values in 5D array")
+
+  end subroutine read_grid_5d_<T>
+
 
   subroutine read_grid_4d_<T>(group, path, array, geo)
 
@@ -94,6 +134,22 @@ contains
     if(any(is_nan(array))) call error("read_grid_3d", "NaN values in 3D array")
 
   end subroutine read_grid_3d_<T>
+
+
+  subroutine write_grid_5d_<T>(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    @T, intent(in) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in) :: geo
+
+    call mp_write_array(group, path, array)
+    call mp_write_keyword(group, path, 'geometry', geo%id)
+
+  end subroutine write_grid_5d_<T>
+
 
   subroutine write_grid_4d_<T>(group, path, array, geo)
 

--- a/src/grid/grid_io_amr.f90
+++ b/src/grid/grid_io_amr.f90
@@ -213,7 +213,7 @@ contains
   end subroutine read_grid_3d_int8
 
 
-  !DN CRAZY ADDITIONS
+
     subroutine write_grid_5d_int8(group, path, array, geo)
 
     implicit none
@@ -458,7 +458,7 @@ contains
 
   end subroutine read_grid_3d_int
 
-  !DN CRAZY ADDITIONS
+
   subroutine write_grid_5d_int(group, path, array, geo)
 
     implicit none
@@ -698,7 +698,7 @@ contains
   end subroutine read_grid_3d_dp
 
 
-!DN CRAZY ADDITIONS
+
   subroutine write_grid_5d_dp(group, path, array, geo)
 
     implicit none
@@ -937,7 +937,7 @@ contains
   end subroutine read_grid_3d_sp
 
 
-!DN CRAZY ADDITIONS
+
   subroutine write_grid_5d_sp(group, path, array, geo)
 
     implicit none

--- a/src/grid/grid_io_amr.f90
+++ b/src/grid/grid_io_amr.f90
@@ -31,21 +31,6 @@ module grid_io
      module procedure read_grid_4d_int8
   end interface read_grid_4d
 
-!  The 5d grid reading is commented out currently becuase the compilation crashes in read_grid_5d, owing to some issue in the where statement.  we get an error:
-
-!src/grid/grid_io_amr.f90(113): error #6783: The variable being defined does not conform with the mask-expr of the where-construct or where-stmt.   [ARRAY5D]
-!                array5d(:,:,:,:,:) = 0
-
-!i think this could be due to something that needs to be updated in type_grid_amr.f90 
-
-!  interface read_grid_5d
-!     module procedure read_grid_5d_sp
-!     module procedure read_grid_5d_dp
-!     module procedure read_grid_5d_int
-!     module procedure read_grid_5d_int8
-!  end interface read_grid_5d
-
-
   interface write_grid_3d
      module procedure write_grid_3d_sp
      module procedure write_grid_3d_dp
@@ -91,47 +76,6 @@ contains
        grid_exists = .false.
     end if
   end function grid_exists
-
-
-! subroutine read_grid_5d_int8(group, path, array, geo)
-
-!    implicit none
-
-!    integer(hid_t), intent(in) :: group
-!    character(len=*), intent(in) :: path
-!    integer(idp), intent(out) :: array(:,:,:)
-!    type(grid_geometry_desc),intent(in),target :: geo
-!    integer(idp), allocatable :: array5d(:,:,:,:,:)
-!    character(len=100) :: full_path
-!    integer :: ilevel, igrid, idust
-!    type(level_desc), pointer :: level
-!    type(grid_desc), pointer :: grid
-
-!    do ilevel=1,size(geo%levels)
-!       level => geo%levels(ilevel)
-!       do igrid=1,size(level%grids)
-!          grid => level%grids(igrid)
-!          write(full_path, '("level_", I5.5, "/grid_", I5.5,"/")') ilevel, igrid
-!          full_path = trim(full_path)//trim(path)
-!          call mp_read_array_auto(group, full_path, array5d)
-!          if(any(is_nan(array5d))) call error("read_grid_5d", "NaN values in 5D array")
-!          do idust=1,size(array5d, 5)
-!             where(grid%goto_grid(1:grid%n1,1:grid%n2,1:grid%n3) > 0)
-!                array5d(:,:,:,:,idust) = 0
-!             end where
-!          end do
-!          array(grid%start_id:grid%start_id + grid%n_cells - 1, :, :) = reshape(array5d, (/grid%n_cells, size(array, 2), size(array,3)/))
-!       end do
-!    end do
-
-!    ! The following three lines provide a workaround for the PGI Fortran
-!    ! compiler, which otherwise crashes with the following error:
-!    ! 0: RESHAPE: result type != SOURCE type
-!  contains
-!    subroutine test()
-!    end subroutine test
-
-!  end subroutine read_grid_5d_int8
 
 
   subroutine read_grid_4d_int8(group, path, array, geo)
@@ -339,47 +283,6 @@ contains
 
 
 
-!  subroutine read_grid_5d_int(group, path, array, geo)
-
-!    implicit none
-
-!    integer(hid_t), intent(in) :: group
-!    character(len=*), intent(in) :: path
-!    integer, intent(out) :: array(:,:,:)
-!    type(grid_geometry_desc),intent(in),target :: geo
-!    integer, allocatable :: array5d(:,:,:,:,:)
-!    character(len=100) :: full_path
-!    integer :: ilevel, igrid, idust
-!    type(level_desc), pointer :: level
-!    type(grid_desc), pointer :: grid
-
-!    do ilevel=1,size(geo%levels)
-!       level => geo%levels(ilevel)
-!       do igrid=1,size(level%grids)
-!          grid => level%grids(igrid)
-!          write(full_path, '("level_", I5.5, "/grid_", I5.5,"/")') ilevel, igrid
-!          full_path = trim(full_path)//trim(path)
-!          call mp_read_array_auto(group, full_path, array5d)
-!          if(any(is_nan(array5d))) call error("read_grid_5d", "NaN values in 5D array")
-!          do idust=1,size(array5d, 5)
-!             where(grid%goto_grid(1:grid%n1,1:grid%n2,1:grid%n3) > 0)
-!                array5d(:,:,:,:,idust) = 0
-!             end where
-!          end do
-!          array(grid%start_id:grid%start_id + grid%n_cells - 1, :, :) = reshape(array5d, (/grid%n_cells, size(array, 2), size(array,3)/))
-!       end do
-!    end do
-
-!    ! The following three lines provide a workaround for the PGI Fortran
-!    ! compiler, which otherwise crashes with the following error:
-!    ! 0: RESHAPE: result type != SOURCE type
-!  contains
-!    subroutine test()
-!    end subroutine test
-
-!  end subroutine read_grid_5d_int
-
-
   subroutine read_grid_4d_int(group, path, array, geo)
 
     implicit none
@@ -578,46 +481,6 @@ contains
 
   end subroutine write_grid_3d_int
 
-
-!  subroutine read_grid_5d_dp(group, path, array, geo)
-
-!    implicit none
-
-!    integer(hid_t), intent(in) :: group
-!    character(len=*), intent(in) :: path
-!    real(dp), intent(out) :: array(:,:,:)
-!    type(grid_geometry_desc),intent(in),target :: geo
-!    real(dp), allocatable :: array5d(:,:,:,:,:)
-!    character(len=100) :: full_path
-!    integer :: ilevel, igrid, idust
-!    type(level_desc), pointer :: level
-!    type(grid_desc), pointer :: grid
-
-!    do ilevel=1,size(geo%levels)
-!       level => geo%levels(ilevel)
-!       do igrid=1,size(level%grids)
-!          grid => level%grids(igrid)
-!          write(full_path, '("level_", I5.5, "/grid_", I5.5,"/")') ilevel, igrid
-!          full_path = trim(full_path)//trim(path)
-!          call mp_read_array_auto(group, full_path, array5d)
-!          if(any(is_nan(array5d))) call error("read_grid_5d", "NaN values in 5D array")
-!          do idust=1,size(array5d, 5)
-!             where(grid%goto_grid(1:grid%n1,1:grid%n2,1:grid%n3) > 0)
-!                array5d(:,:,:,:,idust) = 0
-!             end where
-!          end do
-!          array(grid%start_id:grid%start_id + grid%n_cells - 1, :, :) = reshape(array5d, (/grid%n_cells, size(array, 2), size(array,3)/))
-!       end do
-!    end do
-
-!    ! The following three lines provide a workaround for the PGI Fortran
-!    ! compiler, which otherwise crashes with the following error:
-!    ! 0: RESHAPE: result type != SOURCE type
-!  contains
-!    subroutine test()
-!    end subroutine test
-
-!  end subroutine read_grid_5d_dp
 
   subroutine read_grid_4d_dp(group, path, array, geo)
 
@@ -818,45 +681,6 @@ contains
 
   end subroutine write_grid_3d_dp
 
-!  subroutine read_grid_5d_sp(group, path, array, geo)
-
-!    implicit none
-
-!    integer(hid_t), intent(in) :: group
-!    character(len=*), intent(in) :: path
-!    real(sp), intent(out) :: array(:,:,:)
-!    type(grid_geometry_desc),intent(in),target :: geo
-!    real(sp), allocatable :: array5d(:,:,:,:,:)
-!    character(len=100) :: full_path
-!    integer :: ilevel, igrid, idust
-!    type(level_desc), pointer :: level
-!    type(grid_desc), pointer :: grid
-
-!    do ilevel=1,size(geo%levels)
-!       level => geo%levels(ilevel)
-!       do igrid=1,size(level%grids)
-!          grid => level%grids(igrid)
-!          write(full_path, '("level_", I5.5, "/grid_", I5.5,"/")') ilevel, igrid
-!          full_path = trim(full_path)//trim(path)
-!          call mp_read_array_auto(group, full_path, array5d)
-!          if(any(is_nan(array5d))) call error("read_grid_5d", "NaN values in 5D array")
-!          do idust=1,size(array5d, 5)
-!             where(grid%goto_grid(1:grid%n1,1:grid%n2,1:grid%n3) > 0)
-!                array5d(:,:,:,:,idust) = 0
-!             end where
-!          end do
-!          array(grid%start_id:grid%start_id + grid%n_cells - 1, :,:) = reshape(array5d, (/grid%n_cells, size(array, 2),size(array,3)/))
-!       end do
-!    end do
-
-!    ! The following three lines provide a workaround for the PGI Fortran
-!    ! compiler, which otherwise crashes with the following error:
-!    ! 0: RESHAPE: result type != SOURCE type
-!  contains
-!    subroutine test()
-!    end subroutine test
-
-!  end subroutine read_grid_5d_sp
 
   subroutine read_grid_4d_sp(group, path, array, geo)
 

--- a/src/grid/grid_io_amr.f90
+++ b/src/grid/grid_io_amr.f90
@@ -14,6 +14,8 @@ module grid_io
   public :: read_grid_4d
   public :: write_grid_3d
   public :: write_grid_4d
+  public :: write_grid_5d
+
 
   interface read_grid_3d
      module procedure read_grid_3d_sp
@@ -42,6 +44,14 @@ module grid_io
      module procedure write_grid_4d_int
      module procedure write_grid_4d_int8
   end interface write_grid_4d
+
+  interface write_grid_5d
+     module procedure write_grid_5d_sp
+     module procedure write_grid_5d_dp
+     module procedure write_grid_5d_int
+     module procedure write_grid_5d_int8
+  end interface write_grid_5d
+  
 
 contains
 
@@ -145,6 +155,51 @@ contains
     end subroutine test
 
   end subroutine read_grid_3d_int8
+
+
+  !DN CRAZY ADDITIONS
+    subroutine write_grid_5d_int8(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    integer(idp), intent(in) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in),target :: geo
+    integer(hid_t) :: g_level, g_grid
+    character(len=100) :: name
+    integer :: ilevel, igrid
+    type(level_desc), pointer :: level
+    type(grid_desc), pointer :: grid
+
+    do ilevel=1,size(geo%levels)
+       level => geo%levels(ilevel)
+       write(name, '("level_", I5.5)') ilevel
+       if(mp_path_exists(group, name)) then
+          g_level = mp_open_group(group, name)
+       else
+          g_level = mp_create_group(group, name)
+       end if
+       do igrid=1,size(level%grids)
+          grid => level%grids(igrid)
+          write(name, '("grid_", I5.5)') igrid
+          if(mp_path_exists(g_level, name)) then
+             g_grid = mp_open_group(g_level, name)
+          else
+             g_grid = mp_create_group(g_level, name)
+          end if
+          call mp_write_array(g_grid, path, reshape(array(grid%start_id:grid%start_id + grid%n_cells - 1, :), &
+               &                                     (/grid%n1, grid%n2, grid%n3, size(array,2), size(array,3)/)))
+          call mp_close_group(g_grid)
+       end do
+       call mp_close_group(g_level)
+
+    end do
+
+  end subroutine write_grid_5d_int8
+
+
+
 
   subroutine write_grid_4d_int8(group, path, array, geo)
 
@@ -304,6 +359,47 @@ contains
 
   end subroutine read_grid_3d_int
 
+
+  subroutine write_grid_5d_int(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    integer, intent(in) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in),target :: geo
+    integer(hid_t) :: g_level, g_grid
+    character(len=100) :: name
+    integer :: ilevel, igrid
+    type(level_desc), pointer :: level
+    type(grid_desc), pointer :: grid
+
+    do ilevel=1,size(geo%levels)
+       level => geo%levels(ilevel)
+       write(name, '("level_", I5.5)') ilevel
+       if(mp_path_exists(group, name)) then
+          g_level = mp_open_group(group, name)
+       else
+          g_level = mp_create_group(group, name)
+       end if
+       do igrid=1,size(level%grids)
+          grid => level%grids(igrid)
+          write(name, '("grid_", I5.5)') igrid
+          if(mp_path_exists(g_level, name)) then
+             g_grid = mp_open_group(g_level, name)
+          else
+             g_grid = mp_create_group(g_level, name)
+          end if
+          call mp_write_array(g_grid, path, reshape(array(grid%start_id:grid%start_id + grid%n_cells - 1, :), &
+               &                                     (/grid%n1, grid%n2, grid%n3, size(array,2), size(array,3)/)))
+          call mp_close_group(g_grid)
+       end do
+       call mp_close_group(g_level)
+    end do
+    
+  end subroutine write_grid_5d_int
+
+
   subroutine write_grid_4d_int(group, path, array, geo)
 
     implicit none
@@ -462,6 +558,48 @@ contains
 
   end subroutine read_grid_3d_dp
 
+
+!DN CRAZY ADDITIONS
+  subroutine write_grid_5d_dp(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    real(dp), intent(in) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in),target :: geo
+    integer(hid_t) :: g_level, g_grid
+    character(len=100) :: name
+    integer :: ilevel, igrid
+    type(level_desc), pointer :: level
+    type(grid_desc), pointer :: grid
+
+    do ilevel=1,size(geo%levels)
+       level => geo%levels(ilevel)
+       write(name, '("level_", I5.5)') ilevel
+       if(mp_path_exists(group, name)) then
+          g_level = mp_open_group(group, name)
+       else
+          g_level = mp_create_group(group, name)
+       end if
+       do igrid=1,size(level%grids)
+          grid => level%grids(igrid)
+          write(name, '("grid_", I5.5)') igrid
+          if(mp_path_exists(g_level, name)) then
+             g_grid = mp_open_group(g_level, name)
+          else
+             g_grid = mp_create_group(g_level, name)
+          end if
+          call mp_write_array(g_grid, path, reshape(array(grid%start_id:grid%start_id + grid%n_cells - 1, :), &
+               &                                     (/grid%n1, grid%n2, grid%n3, size(array,2), size(array,3)/)))
+          call mp_close_group(g_grid)
+       end do
+       call mp_close_group(g_level)
+    end do
+
+  end subroutine write_grid_5d_dp
+
+
   subroutine write_grid_4d_dp(group, path, array, geo)
 
     implicit none
@@ -619,6 +757,49 @@ contains
     end subroutine test
 
   end subroutine read_grid_3d_sp
+
+
+!DN CRAZY ADDITIONS
+  subroutine write_grid_5d_sp(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    real(sp), intent(in) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in),target :: geo
+    integer(hid_t) :: g_level, g_grid
+    character(len=100) :: name
+    integer :: ilevel, igrid
+    type(level_desc), pointer :: level
+    type(grid_desc), pointer :: grid
+
+    do ilevel=1,size(geo%levels)
+       level => geo%levels(ilevel)
+       write(name, '("level_", I5.5)') ilevel
+       if(mp_path_exists(group, name)) then
+          g_level = mp_open_group(group, name)
+       else
+          g_level = mp_create_group(group, name)
+       end if
+       do igrid=1,size(level%grids)
+          grid => level%grids(igrid)
+          write(name, '("grid_", I5.5)') igrid
+          if(mp_path_exists(g_level, name)) then
+             g_grid = mp_open_group(g_level, name)
+          else
+             g_grid = mp_create_group(g_level, name)
+          end if
+          call mp_write_array(g_grid, path, reshape(array(grid%start_id:grid%start_id + grid%n_cells - 1, :), &
+               &                                     (/grid%n1, grid%n2, grid%n3, size(array,2),size(array,3)/)))
+          call mp_close_group(g_grid)
+       end do
+       call mp_close_group(g_level)
+    end do
+
+  end subroutine write_grid_5d_sp
+
+
 
   subroutine write_grid_4d_sp(group, path, array, geo)
 

--- a/src/grid/grid_io_amr_template.f90
+++ b/src/grid/grid_io_amr_template.f90
@@ -158,7 +158,7 @@ contains
   end subroutine read_grid_3d_<T>
 
 
-  !DN CRAZY ADDITIONS
+
   subroutine write_grid_5d_<T>(group, path, array, geo)
 
     implicit none

--- a/src/grid/grid_io_amr_template.f90
+++ b/src/grid/grid_io_amr_template.f90
@@ -13,6 +13,8 @@ module grid_io
   public :: read_grid_4d
   public :: write_grid_3d
   public :: write_grid_4d
+  public :: write_grid_5d
+
 
   interface read_grid_3d
      module procedure read_grid_3d_sp
@@ -41,6 +43,15 @@ module grid_io
      module procedure write_grid_4d_int
      module procedure write_grid_4d_int8
   end interface write_grid_4d
+
+  interface write_grid_5d
+     module procedure write_grid_5d_sp
+     module procedure write_grid_5d_dp
+     module procedure write_grid_5d_int
+     module procedure write_grid_5d_int8
+  end interface write_grid_5d
+  
+  
 
 contains
 
@@ -145,6 +156,48 @@ contains
     end subroutine test
 
   end subroutine read_grid_3d_<T>
+
+
+  !DN CRAZY ADDITIONS
+  subroutine write_grid_5d_<T>(group, path, array, geo)
+
+    implicit none
+
+    integer(hid_t), intent(in) :: group
+    character(len=*), intent(in) :: path
+    @T, intent(in) :: array(:,:,:)
+    type(grid_geometry_desc),intent(in),target :: geo
+    integer(hid_t) :: g_level, g_grid
+    character(len=100) :: name
+    integer :: ilevel, igrid
+    type(level_desc), pointer :: level
+    type(grid_desc), pointer :: grid
+
+    do ilevel=1,size(geo%levels)
+       level => geo%levels(ilevel)
+       write(name, '("level_", I5.5)') ilevel
+       if(mp_path_exists(group, name)) then
+          g_level = mp_open_group(group, name)
+       else
+          g_level = mp_create_group(group, name)
+       end if
+       do igrid=1,size(level%grids)
+          grid => level%grids(igrid)
+          write(name, '("grid_", I5.5)') igrid
+          if(mp_path_exists(g_level, name)) then
+             g_grid = mp_open_group(g_level, name)
+          else
+             g_grid = mp_create_group(g_level, name)
+          end if
+          call mp_write_array(g_grid, path, reshape(array(grid%start_id:grid%start_id + grid%n_cells - 1, :), &
+               &                                     (/grid%n1, grid%n2, grid%n3, size(array,2), size(array,3)/)))
+          call mp_close_group(g_grid)
+       end do
+       call mp_close_group(g_level)
+
+    end do
+
+  end subroutine write_grid_5d_<T>
 
   subroutine write_grid_4d_<T>(group, path, array, geo)
 

--- a/src/grid/grid_io_amr_template.f90
+++ b/src/grid/grid_io_amr_template.f90
@@ -189,7 +189,7 @@ contains
           else
              g_grid = mp_create_group(g_level, name)
           end if
-          call mp_write_array(g_grid, path, reshape(array(grid%start_id:grid%start_id + grid%n_cells - 1, :), &
+          call mp_write_array(g_grid, path, reshape(array(grid%start_id:grid%start_id + grid%n_cells - 1, :, :), &
                &                                     (/grid%n1, grid%n2, grid%n3, size(array,2), size(array,3)/)))
           call mp_close_group(g_grid)
        end do

--- a/src/grid/grid_io_template.f90
+++ b/src/grid/grid_io_template.f90
@@ -11,7 +11,6 @@ module grid_io
   public :: grid_exists
   public :: read_grid_3d
   public :: read_grid_4d
-  public :: read_grid_5d
   public :: write_grid_3d
   public :: write_grid_4d
   public :: write_grid_5d
@@ -30,13 +29,6 @@ module grid_io
      module procedure read_grid_4d_int
      module procedure read_grid_4d_int8
   end interface read_grid_4d
-
-  interface read_grid_5d
-     module procedure read_grid_5d_sp
-     module procedure read_grid_5d_dp
-     module procedure read_grid_5d_int
-     module procedure read_grid_5d_int8
-  end interface read_grid_5d
 
   interface write_grid_3d
      module procedure write_grid_3d_sp
@@ -70,37 +62,6 @@ contains
   end function grid_exists
 
   !!@FOR real(sp):sp real(dp):dp integer:int integer(idp):int8
-
-
-  subroutine read_grid_5d_<T>(group, path, array, geo)
-      
-    implicit none
-
-    integer(hid_t), intent(in) :: group
-    character(len=*), intent(in) :: path
-    @T, intent(out) :: array(:,:,:)
-    type(grid_geometry_desc),intent(in) :: geo
-    @T, allocatable :: array5d(:,:,:,:,:)
-    integer :: n_cells, n_dust, n_isrf_lam
-
-    character(len=32) :: geometry_id_check
-
-    call mp_read_keyword(group,path, 'geometry', geometry_id_check)
-    if(geometry_id_check.ne.geo%id) then
-       call error("read_grid", "geometry IDs do not match")
-    end if
-    call mp_read_array_auto(group,path, array5d)
-
-    if(any(is_nan(array5d))) call error("read_grid_5d", "NaN values in 5D array")
-
-    n_cells = size(array, 1)
-    n_dust = size(array, 2)
-    n_isrf_lam = size(array,3)
-
-    array = reshape(array5d, (/n_cells, n_dust, n_isrf_lam/))
-
-  end subroutine read_grid_5d_<T>
-  
 
 
   subroutine read_grid_4d_<T>(group, path, array, geo)

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -3,7 +3,7 @@ module grid_physics
   use core_lib
   use type_photon
   use type_grid_cell
-  use grid_io, only : read_grid_4d, grid_exists, read_grid_5d
+  use grid_io, only : read_grid_4d, grid_exists
   use dust_main ! many variables and routines
   use type_dust
   use grid_geometry

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -153,7 +153,6 @@ contains
 
           ! Read in specific_energy
           call read_grid_4d(group, 'specific_energy', specific_energy, geo)
-          call read_grid_5d(group, 'specific_energy_nu', specific_energy_nu, geo)
 
           ! Check number of dust types for specific_energy
           if(size(specific_energy, 2).ne.n_dust) call error("setup_grid","specific_energy array has wrong number of dust types")

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -193,6 +193,8 @@ contains
     allocate(specific_energy_sum(geo%n_cells, n_dust))
     specific_energy_sum = 0._dp
 
+
+    !DN CRAZY ADDITION
     allocate(specific_energy_sum_nu(geo%n_cells, n_dust, 10))
     specific_energy_sum_nu = 0._dp
     

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -196,8 +196,7 @@ contains
     allocate(specific_energy_sum(geo%n_cells, n_dust))
     specific_energy_sum = 0._dp
 
-
-    !DN CRAZY ADDITION
+    ! Set up basics for ISRF calculation
     n_isrf_wavelengths = d(1)%n_nu
     allocate(specific_energy_sum_nu(geo%n_cells, n_dust, n_isrf_wavelengths))
     specific_energy_sum_nu = 0._dp

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -37,6 +37,8 @@ module grid_physics
   integer(idp),allocatable, public :: last_photon_id(:)
   real(dp),allocatable, public :: specific_energy(:,:)
   real(dp),allocatable, public :: specific_energy_sum(:,:)
+  real(dp),allocatable, public :: specific_energy_sum_nu(:,:,:)
+
   real(dp),allocatable, public :: specific_energy_additional(:,:)
   real(dp),allocatable, public :: energy_abs_tot(:)
   real(dp),allocatable, public :: minimum_specific_energy(:)
@@ -190,6 +192,9 @@ contains
     ! Specific energy summation
     allocate(specific_energy_sum(geo%n_cells, n_dust))
     specific_energy_sum = 0._dp
+
+    allocate(specific_energy_sum_nu(geo%n_cells, n_dust, 10))
+    specific_energy_sum_nu = 0._dp
 
     ! Total energy absorbed
     allocate(energy_abs_tot(n_dust))

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -59,6 +59,8 @@ module grid_physics
 
   type(pdf_discrete_dp) :: absorption
 
+
+
 contains
 
   real(dp) function tau_inv_planck_to_closest_wall(p) result(tau)
@@ -97,6 +99,7 @@ contains
 
     integer(hid_t),intent(in) :: group
     logical,intent(in) :: use_mrw, use_pda
+    integer :: n_isrf_wavelengths
 
     ! Density
     allocate(density(geo%n_cells, n_dust))
@@ -195,7 +198,8 @@ contains
 
 
     !DN CRAZY ADDITION
-    allocate(specific_energy_sum_nu(geo%n_cells, n_dust, 10))
+    n_isrf_wavelengths = d(1)%n_nu
+    allocate(specific_energy_sum_nu(geo%n_cells, n_dust, n_isrf_wavelengths))
     specific_energy_sum_nu = 0._dp
     
     ! Total energy absorbed

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -195,7 +195,7 @@ contains
 
     allocate(specific_energy_sum_nu(geo%n_cells, n_dust, 10))
     specific_energy_sum_nu = 0._dp
-
+    
     ! Total energy absorbed
     allocate(energy_abs_tot(n_dust))
     energy_abs_tot = 0._dp

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -3,7 +3,7 @@ module grid_physics
   use core_lib
   use type_photon
   use type_grid_cell
-  use grid_io, only : read_grid_4d, grid_exists
+  use grid_io, only : read_grid_4d, grid_exists, read_grid_5d
   use dust_main ! many variables and routines
   use type_dust
   use grid_geometry
@@ -36,10 +36,12 @@ module grid_physics
   integer(idp),allocatable, public :: n_photons(:)
   integer(idp),allocatable, public :: last_photon_id(:)
   real(dp),allocatable, public :: specific_energy(:,:)
+  real(dp),allocatable, public :: specific_energy_nu(:,:,:) 
   real(dp),allocatable, public :: specific_energy_sum(:,:)
   real(dp),allocatable, public :: specific_energy_sum_nu(:,:,:)
 
   real(dp),allocatable, public :: specific_energy_additional(:,:)
+  real(dp),allocatable, public :: specific_energy_additional_nu(:,:,:)
   real(dp),allocatable, public :: energy_abs_tot(:)
   real(dp),allocatable, public :: minimum_specific_energy(:)
 
@@ -53,7 +55,9 @@ module grid_physics
   ! Temporary variables (used for convenience in external modules)
   real(dp), allocatable, public :: tmp_column_density(:)
 
+  !Counting indices
   integer :: id
+  integer :: idx 
 
   logical :: debug = .false.
 
@@ -101,9 +105,11 @@ contains
     logical,intent(in) :: use_mrw, use_pda, compute_isrf
     integer :: n_isrf_wavelengths
 
+    n_isrf_wavelengths = d(1)%n_nu
     ! Density
     allocate(density(geo%n_cells, n_dust))
     allocate(specific_energy(geo%n_cells, n_dust))
+    allocate(specific_energy_nu(geo%n_cells,n_dust,n_isrf_wavelengths))
 
     if(n_dust > 0) then
 
@@ -147,9 +153,12 @@ contains
 
           ! Read in specific_energy
           call read_grid_4d(group, 'specific_energy', specific_energy, geo)
+          call read_grid_5d(group, 'specific_energy_nu', specific_energy_nu, geo)
 
           ! Check number of dust types for specific_energy
           if(size(specific_energy, 2).ne.n_dust) call error("setup_grid","specific_energy array has wrong number of dust types")
+
+
 
           ! Reset specific energy to zero in masked cells
           if(geo%masked) then
@@ -158,19 +167,39 @@ contains
                 where(.not.geo%mask)
                    specific_energy(:, id) = 0.
                 end where
+                
+                if (compute_isrf) then
+                   do idx=1,n_isrf_wavelengths
+                      where(.not.geo%mask)
+                         specific_energy_nu(:, id, idx) = 0.
+                      endwhere
+                   end do
+                end if
+
              end do
           end if
 
           if(trim(specific_energy_type) == 'additional') then
              allocate(specific_energy_additional(geo%n_cells, n_dust))
+             if (compute_isrf) then 
+                allocate(specific_energy_additional_nu(geo%n_cells,n_dust,n_isrf_wavelengths))
+             end if
              ! We store a copy of the initial specific energy in a separate
              ! array, and we set the specific energy to the minimum specific
              ! energy. After the first iteration, specific_energy will get
              ! re-calculated and we will then add specific_energy_additional
              specific_energy_additional = specific_energy
+             specific_energy_additional_nu = specific_energy_nu
              do id=1,n_dust
                 specific_energy(:,id) = minimum_specific_energy(id)
-             end do
+                
+                if (compute_isrf) then
+                   do idx=1,n_isrf_wavelengths
+                      specific_energy_nu(:,id,idx) = minimum_specific_energy(id)
+                   end do
+                end if
+
+            end do
           end if
 
 
@@ -183,6 +212,13 @@ contains
           ! Set all specific_energy to minimum requested
           do id=1,n_dust
              specific_energy(:,id) = minimum_specific_energy(id)
+
+             if (compute_isrf) then
+                do idx = 1,n_isrf_wavelengths
+                   specific_energy_nu(:,id,idx) = minimum_specific_energy(id)
+                end do
+             end if
+
           end do
 
        end if
@@ -197,7 +233,7 @@ contains
     specific_energy_sum = 0._dp
 
     ! Set up basics for ISRF calculation
-    n_isrf_wavelengths = d(1)%n_nu
+    !n_isrf_wavelengths = d(1)%n_nu
     allocate(specific_energy_sum_nu(geo%n_cells, n_dust, n_isrf_wavelengths))
     specific_energy_sum_nu = 0._dp
     
@@ -267,6 +303,9 @@ contains
     implicit none
     integer :: ic, id
     integer :: reset
+    integer :: n_isrf_wavelengths
+
+    n_isrf_wavelengths = d(1)%n_nu
 
     reset = 0
 
@@ -280,7 +319,15 @@ contains
                 density(ic, id) = 0.
                 specific_energy(ic, id) = minimum_specific_energy(id)
                 reset = reset + 1
+
+                if (compute_isrf) then
+                   do idx=1,n_isrf_wavelengths
+                      specific_energy_nu(ic,id,idx) = minimum_specific_energy(id)
+                   end do
+                end if
+
              end if
+             
           end do
           if(reset > 0) write(*,'(" [sublimate_dust] dust removed in ",I0," cells")') reset
 
@@ -294,6 +341,14 @@ contains
                      & / chi_rosseland(id, d(id)%sublimation_specific_energy))**2
                 specific_energy(ic,id) = d(id)%sublimation_specific_energy
                 reset = reset + 1
+
+
+                if (compute_isrf) then
+                   do idx=1,n_isrf_wavelengths
+                      specific_energy_nu(ic,id,idx) = minimum_specific_energy(id)
+                   end do
+                end if
+                   
              end if
           end do
 
@@ -306,6 +361,14 @@ contains
                 specific_energy(ic, id) = d(id)%sublimation_specific_energy
                 reset = reset + 1
              end if
+
+             
+             if (compute_isrf) then
+                do idx=1,n_isrf_wavelengths
+                   specific_energy_nu(ic,id,idx) = minimum_specific_energy(id)
+                end do
+             end if
+
           end do
 
           if(reset > 0) write(*,'(" [sublimate_dust] capping dust specific_energy in ",I0," cells")') reset
@@ -326,12 +389,23 @@ contains
 
     real(dp), intent(in) :: scale
 
-    integer :: id
+    integer :: id,idx
+    integer :: n_isrf_wavelengths
+    
+    n_isrf_wavelengths = d(1)%n_nu
 
     if(main_process()) write(*,'(" [grid_physics] updating energy_abs")')
 
     do id=1,n_dust
        specific_energy(:,id) = specific_energy_sum(:,id) * scale / geo%volume
+       
+       if (compute_isrf) then
+          do idx=1,n_isrf_wavelengths
+             specific_energy_nu(:,id,idx) = specific_energy_sum_nu(:,id,idx) * scale/geo%volume
+          end do
+       end if
+          
+          
        where(geo%volume == 0._dp)
           specific_energy(:,id) = 0._dp
        end where
@@ -341,10 +415,17 @@ contains
        write(*,'(" [update_energy_abs] ",I0," cells have no energy")') count(specific_energy==0.and.density>0.)
     end if
 
+
     ! Add in additional source of heating
     if(trim(specific_energy_type) == 'additional') then
        if(main_process()) write(*,'(" [grid_physics] adding additional heating source")')
        specific_energy = specific_energy + specific_energy_additional
+
+       
+       if (compute_isrf) then 
+          specific_energy_nu = specific_energy_nu + specific_energy_additional_nu
+       end if
+
     end if
 
     call update_energy_abs_tot()
@@ -367,7 +448,10 @@ contains
           if(main_process()) call warn("update_energy_abs","specific_energy below minimum requested in some cells - resetting")
           where(specific_energy(:,id) < minimum_specific_energy(id))
              specific_energy(:,id) = minimum_specific_energy(id)
+             
+ 
           end where
+
        end if
 
        if(any(specific_energy(:,id) < d(id)%specific_energy(1))) then
@@ -375,7 +459,8 @@ contains
              if(main_process()) call warn("update_energy_abs","specific_energy below minimum allowed in some cells - resetting")
              where(specific_energy(:,id) < d(id)%specific_energy(1))
                 specific_energy(:,id) = d(id)%specific_energy(1)
-             end where
+                
+              end where
           else
              if(main_process()) call warn("update_energy_abs","specific_energy below minimum allowed in some cells - will pick closest emissivities")
           end if
@@ -386,6 +471,7 @@ contains
              if(main_process()) call warn("update_energy_abs","specific_energy above maximum allowed in some cells - resetting")
              where(specific_energy(:,id) > d(id)%specific_energy(d(id)%n_e))
                 specific_energy(:,id) = d(id)%specific_energy(d(id)%n_e)
+
              end where
           else
              if(main_process()) call warn("update_energy_abs","specific_energy above maximum allowed in some cells - will pick closest emissivities")

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -93,12 +93,12 @@ contains
     id_select = sample_pdf(absorption)
   end function select_dust_specific_energy_rho
 
-  subroutine setup_grid_physics(group, use_mrw, use_pda)
+  subroutine setup_grid_physics(group, use_mrw, use_pda, compute_isrf)
 
     implicit none
 
     integer(hid_t),intent(in) :: group
-    logical,intent(in) :: use_mrw, use_pda
+    logical,intent(in) :: use_mrw, use_pda, compute_isrf
     integer :: n_isrf_wavelengths
 
     ! Density

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -40,6 +40,7 @@ module grid_physics
   real(dp),allocatable, public :: specific_energy_sum(:,:)
   real(dp),allocatable, public :: specific_energy_sum_nu(:,:,:)
   real(dp),allocatable, public :: isrf_nu(:)
+  real(dp),allocatable, public :: log_isrf_nu(:)
 
   real(dp),allocatable, public :: specific_energy_additional(:,:)
   real(dp),allocatable, public :: specific_energy_additional_nu(:,:,:)
@@ -106,7 +107,13 @@ contains
     logical,intent(in) :: use_mrw, use_pda, compute_isrf
     integer :: n_isrf_wavelengths
 
-    n_isrf_wavelengths = d(1)%n_nu
+    ! The ISRF is binned onto a user-specified frequency grid if one was given,
+    ! otherwise onto the frequency grid of the first dust type.
+    if (allocated(isrf_frequencies)) then
+       n_isrf_wavelengths = size(isrf_frequencies)
+    else
+       n_isrf_wavelengths = d(1)%n_nu
+    end if
     ! Density
     allocate(density(geo%n_cells, n_dust))
     allocate(specific_energy(geo%n_cells, n_dust))
@@ -236,12 +243,20 @@ contains
     allocate(specific_energy_sum_nu(geo%n_cells, n_dust, n_isrf_wavelengths))
     specific_energy_sum_nu = 0._dp
 
-    ! Cache the ISRF frequency grid once so it does not have to be rebuilt for every photon
+    ! Cache the ISRF frequency grid (and its log) once so they do not have to be
+    ! rebuilt for every photon. Photons are binned to the nearest grid point in
+    ! log-frequency space (see grid_propagate).
     if (compute_isrf) then
        allocate(isrf_nu(n_isrf_wavelengths))
-       do idx=1,n_isrf_wavelengths
-          isrf_nu(idx) = d(1)%nu(idx)
-       end do
+       if (allocated(isrf_frequencies)) then
+          isrf_nu = isrf_frequencies
+       else
+          do idx=1,n_isrf_wavelengths
+             isrf_nu(idx) = d(1)%nu(idx)
+          end do
+       end if
+       allocate(log_isrf_nu(n_isrf_wavelengths))
+       log_isrf_nu = log10(isrf_nu)
     end if
 
     ! Total energy absorbed
@@ -312,7 +327,7 @@ contains
     integer :: reset
     integer :: n_isrf_wavelengths
 
-    n_isrf_wavelengths = d(1)%n_nu
+    n_isrf_wavelengths = size(specific_energy_nu, 3)
 
     reset = 0
 
@@ -398,8 +413,8 @@ contains
 
     integer :: id,idx
     integer :: n_isrf_wavelengths
-    
-    n_isrf_wavelengths = d(1)%n_nu
+
+    n_isrf_wavelengths = size(specific_energy_nu, 3)
 
     if(main_process()) write(*,'(" [grid_physics] updating energy_abs")')
 

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -39,6 +39,7 @@ module grid_physics
   real(dp),allocatable, public :: specific_energy_nu(:,:,:) 
   real(dp),allocatable, public :: specific_energy_sum(:,:)
   real(dp),allocatable, public :: specific_energy_sum_nu(:,:,:)
+  real(dp),allocatable, public :: isrf_nu(:)
 
   real(dp),allocatable, public :: specific_energy_additional(:,:)
   real(dp),allocatable, public :: specific_energy_additional_nu(:,:,:)
@@ -232,10 +233,15 @@ contains
     specific_energy_sum = 0._dp
 
     ! Set up basics for ISRF calculation
-    !n_isrf_wavelengths = d(1)%n_nu
     allocate(specific_energy_sum_nu(geo%n_cells, n_dust, n_isrf_wavelengths))
     specific_energy_sum_nu = 0._dp
-    
+
+    ! Cache the ISRF frequency grid once so it does not have to be rebuilt for every photon
+    allocate(isrf_nu(n_isrf_wavelengths))
+    do idx=1,n_isrf_wavelengths
+       isrf_nu(idx) = d(1)%nu(idx)
+    end do
+
     ! Total energy absorbed
     allocate(energy_abs_tot(n_dust))
     energy_abs_tot = 0._dp

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -39,8 +39,8 @@ module grid_physics
   real(dp),allocatable, public :: specific_energy_nu(:,:,:) 
   real(dp),allocatable, public :: specific_energy_sum(:,:)
   real(dp),allocatable, public :: specific_energy_sum_nu(:,:,:)
-  real(dp),allocatable, public :: isrf_nu(:)
-  real(dp),allocatable, public :: log_isrf_nu(:)
+  real(dp),allocatable, public :: nu_bins(:)
+  real(dp),allocatable, public :: log_nu_bins(:)
 
   real(dp),allocatable, public :: specific_energy_additional(:,:)
   real(dp),allocatable, public :: specific_energy_additional_nu(:,:,:)
@@ -99,25 +99,25 @@ contains
     id_select = sample_pdf(absorption)
   end function select_dust_specific_energy_rho
 
-  subroutine setup_grid_physics(group, use_mrw, use_pda, compute_isrf)
+  subroutine setup_grid_physics(group, use_mrw, use_pda, compute_specific_energy_nu)
 
     implicit none
 
     integer(hid_t),intent(in) :: group
-    logical,intent(in) :: use_mrw, use_pda, compute_isrf
-    integer :: n_isrf_wavelengths
+    logical,intent(in) :: use_mrw, use_pda, compute_specific_energy_nu
+    integer :: n_nu_bins
 
-    ! The ISRF is binned onto a user-specified frequency grid if one was given,
+    ! specific_energy_nu is binned onto a user-specified frequency grid if one was given,
     ! otherwise onto the frequency grid of the first dust type.
-    if (allocated(isrf_frequencies)) then
-       n_isrf_wavelengths = size(isrf_frequencies)
+    if (allocated(specific_energy_nu_frequencies)) then
+       n_nu_bins = size(specific_energy_nu_frequencies)
     else
-       n_isrf_wavelengths = d(1)%n_nu
+       n_nu_bins = d(1)%n_nu
     end if
     ! Density
     allocate(density(geo%n_cells, n_dust))
     allocate(specific_energy(geo%n_cells, n_dust))
-    allocate(specific_energy_nu(geo%n_cells,n_dust,n_isrf_wavelengths))
+    allocate(specific_energy_nu(geo%n_cells,n_dust,n_nu_bins))
 
     if(n_dust > 0) then
 
@@ -175,8 +175,8 @@ contains
                    specific_energy(:, id) = 0.
                 end where
                 
-                if (compute_isrf) then
-                   do idx=1,n_isrf_wavelengths
+                if (compute_specific_energy_nu) then
+                   do idx=1,n_nu_bins
                       where(.not.geo%mask)
                          specific_energy_nu(:, id, idx) = 0.
                       endwhere
@@ -188,8 +188,8 @@ contains
 
           if(trim(specific_energy_type) == 'additional') then
              allocate(specific_energy_additional(geo%n_cells, n_dust))
-             if (compute_isrf) then 
-                allocate(specific_energy_additional_nu(geo%n_cells,n_dust,n_isrf_wavelengths))
+             if (compute_specific_energy_nu) then 
+                allocate(specific_energy_additional_nu(geo%n_cells,n_dust,n_nu_bins))
              end if
              ! We store a copy of the initial specific energy in a separate
              ! array, and we set the specific energy to the minimum specific
@@ -200,8 +200,8 @@ contains
              do id=1,n_dust
                 specific_energy(:,id) = minimum_specific_energy(id)
                 
-                if (compute_isrf) then
-                   do idx=1,n_isrf_wavelengths
+                if (compute_specific_energy_nu) then
+                   do idx=1,n_nu_bins
                       specific_energy_nu(:,id,idx) = minimum_specific_energy(id)
                    end do
                 end if
@@ -220,8 +220,8 @@ contains
           do id=1,n_dust
              specific_energy(:,id) = minimum_specific_energy(id)
 
-             if (compute_isrf) then
-                do idx = 1,n_isrf_wavelengths
+             if (compute_specific_energy_nu) then
+                do idx = 1,n_nu_bins
                    specific_energy_nu(:,id,idx) = minimum_specific_energy(id)
                 end do
              end if
@@ -239,24 +239,24 @@ contains
     allocate(specific_energy_sum(geo%n_cells, n_dust))
     specific_energy_sum = 0._dp
 
-    ! Set up basics for ISRF calculation
-    allocate(specific_energy_sum_nu(geo%n_cells, n_dust, n_isrf_wavelengths))
+    ! Set up basics for the frequency-resolved specific energy
+    allocate(specific_energy_sum_nu(geo%n_cells, n_dust, n_nu_bins))
     specific_energy_sum_nu = 0._dp
 
-    ! Cache the ISRF frequency grid (and its log) once so they do not have to be
+    ! Cache the frequency grid (and its log) once so they do not have to be
     ! rebuilt for every photon. Photons are binned to the nearest grid point in
     ! log-frequency space (see grid_propagate).
-    if (compute_isrf) then
-       allocate(isrf_nu(n_isrf_wavelengths))
-       if (allocated(isrf_frequencies)) then
-          isrf_nu = isrf_frequencies
+    if (compute_specific_energy_nu) then
+       allocate(nu_bins(n_nu_bins))
+       if (allocated(specific_energy_nu_frequencies)) then
+          nu_bins = specific_energy_nu_frequencies
        else
-          do idx=1,n_isrf_wavelengths
-             isrf_nu(idx) = d(1)%nu(idx)
+          do idx=1,n_nu_bins
+             nu_bins(idx) = d(1)%nu(idx)
           end do
        end if
-       allocate(log_isrf_nu(n_isrf_wavelengths))
-       log_isrf_nu = log10(isrf_nu)
+       allocate(log_nu_bins(n_nu_bins))
+       log_nu_bins = log10(nu_bins)
     end if
 
     ! Total energy absorbed
@@ -325,9 +325,9 @@ contains
     implicit none
     integer :: ic, id
     integer :: reset
-    integer :: n_isrf_wavelengths
+    integer :: n_nu_bins
 
-    n_isrf_wavelengths = size(specific_energy_nu, 3)
+    n_nu_bins = size(specific_energy_nu, 3)
 
     reset = 0
 
@@ -342,8 +342,8 @@ contains
                 specific_energy(ic, id) = minimum_specific_energy(id)
                 reset = reset + 1
 
-                if (compute_isrf) then
-                   do idx=1,n_isrf_wavelengths
+                if (compute_specific_energy_nu) then
+                   do idx=1,n_nu_bins
                       specific_energy_nu(ic,id,idx) = minimum_specific_energy(id)
                    end do
                 end if
@@ -365,8 +365,8 @@ contains
                 reset = reset + 1
 
 
-                if (compute_isrf) then
-                   do idx=1,n_isrf_wavelengths
+                if (compute_specific_energy_nu) then
+                   do idx=1,n_nu_bins
                       specific_energy_nu(ic,id,idx) = minimum_specific_energy(id)
                    end do
                 end if
@@ -385,8 +385,8 @@ contains
              end if
 
              
-             if (compute_isrf) then
-                do idx=1,n_isrf_wavelengths
+             if (compute_specific_energy_nu) then
+                do idx=1,n_nu_bins
                    specific_energy_nu(ic,id,idx) = minimum_specific_energy(id)
                 end do
              end if
@@ -412,17 +412,17 @@ contains
     real(dp), intent(in) :: scale
 
     integer :: id,idx
-    integer :: n_isrf_wavelengths
+    integer :: n_nu_bins
 
-    n_isrf_wavelengths = size(specific_energy_nu, 3)
+    n_nu_bins = size(specific_energy_nu, 3)
 
     if(main_process()) write(*,'(" [grid_physics] updating energy_abs")')
 
     do id=1,n_dust
        specific_energy(:,id) = specific_energy_sum(:,id) * scale / geo%volume
        
-       if (compute_isrf) then
-          do idx=1,n_isrf_wavelengths
+       if (compute_specific_energy_nu) then
+          do idx=1,n_nu_bins
              specific_energy_nu(:,id,idx) = specific_energy_sum_nu(:,id,idx) * scale/geo%volume
           end do
        end if
@@ -444,7 +444,7 @@ contains
        specific_energy = specific_energy + specific_energy_additional
 
        
-       if (compute_isrf) then 
+       if (compute_specific_energy_nu) then 
           specific_energy_nu = specific_energy_nu + specific_energy_additional_nu
        end if
 

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -118,6 +118,13 @@ contains
     allocate(density(geo%n_cells, n_dust))
     allocate(specific_energy(geo%n_cells, n_dust))
     allocate(specific_energy_spectrum(geo%n_cells,n_dust,n_nu_bins))
+    ! initialize: this array is only fully populated later (from the
+    ! photon deposits, or from the minimum specific energy), but with
+    ! specific_energy_type='additional' it is COPIED into
+    ! specific_energy_additional_spectrum before that happens -- copying
+    ! an uninitialized allocation injects heap garbage into the
+    ! frequency-resolved output at every iteration.
+    specific_energy_spectrum = 0._dp
 
     if(n_dust > 0) then
 

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -237,10 +237,12 @@ contains
     specific_energy_sum_nu = 0._dp
 
     ! Cache the ISRF frequency grid once so it does not have to be rebuilt for every photon
-    allocate(isrf_nu(n_isrf_wavelengths))
-    do idx=1,n_isrf_wavelengths
-       isrf_nu(idx) = d(1)%nu(idx)
-    end do
+    if (compute_isrf) then
+       allocate(isrf_nu(n_isrf_wavelengths))
+       do idx=1,n_isrf_wavelengths
+          isrf_nu(idx) = d(1)%nu(idx)
+       end do
+    end if
 
     ! Total energy absorbed
     allocate(energy_abs_tot(n_dust))

--- a/src/grid/grid_physics_3d.f90
+++ b/src/grid/grid_physics_3d.f90
@@ -36,14 +36,14 @@ module grid_physics
   integer(idp),allocatable, public :: n_photons(:)
   integer(idp),allocatable, public :: last_photon_id(:)
   real(dp),allocatable, public :: specific_energy(:,:)
-  real(dp),allocatable, public :: specific_energy_nu(:,:,:) 
+  real(dp),allocatable, public :: specific_energy_spectrum(:,:,:) 
   real(dp),allocatable, public :: specific_energy_sum(:,:)
-  real(dp),allocatable, public :: specific_energy_sum_nu(:,:,:)
+  real(dp),allocatable, public :: specific_energy_sum_spectrum(:,:,:)
   real(dp),allocatable, public :: nu_bins(:)
   real(dp),allocatable, public :: log_nu_bins(:)
 
   real(dp),allocatable, public :: specific_energy_additional(:,:)
-  real(dp),allocatable, public :: specific_energy_additional_nu(:,:,:)
+  real(dp),allocatable, public :: specific_energy_additional_spectrum(:,:,:)
   real(dp),allocatable, public :: energy_abs_tot(:)
   real(dp),allocatable, public :: minimum_specific_energy(:)
 
@@ -99,25 +99,25 @@ contains
     id_select = sample_pdf(absorption)
   end function select_dust_specific_energy_rho
 
-  subroutine setup_grid_physics(group, use_mrw, use_pda, compute_specific_energy_nu)
+  subroutine setup_grid_physics(group, use_mrw, use_pda, compute_specific_energy_spectrum)
 
     implicit none
 
     integer(hid_t),intent(in) :: group
-    logical,intent(in) :: use_mrw, use_pda, compute_specific_energy_nu
+    logical,intent(in) :: use_mrw, use_pda, compute_specific_energy_spectrum
     integer :: n_nu_bins
 
-    ! specific_energy_nu is binned onto a user-specified frequency grid if one was given,
+    ! specific_energy_spectrum is binned onto a user-specified frequency grid if one was given,
     ! otherwise onto the frequency grid of the first dust type.
-    if (allocated(specific_energy_nu_frequencies)) then
-       n_nu_bins = size(specific_energy_nu_frequencies)
+    if (allocated(specific_energy_spectrum_frequencies)) then
+       n_nu_bins = size(specific_energy_spectrum_frequencies)
     else
        n_nu_bins = d(1)%n_nu
     end if
     ! Density
     allocate(density(geo%n_cells, n_dust))
     allocate(specific_energy(geo%n_cells, n_dust))
-    allocate(specific_energy_nu(geo%n_cells,n_dust,n_nu_bins))
+    allocate(specific_energy_spectrum(geo%n_cells,n_dust,n_nu_bins))
 
     if(n_dust > 0) then
 
@@ -175,10 +175,10 @@ contains
                    specific_energy(:, id) = 0.
                 end where
                 
-                if (compute_specific_energy_nu) then
+                if (compute_specific_energy_spectrum) then
                    do idx=1,n_nu_bins
                       where(.not.geo%mask)
-                         specific_energy_nu(:, id, idx) = 0.
+                         specific_energy_spectrum(:, id, idx) = 0.
                       endwhere
                    end do
                 end if
@@ -188,21 +188,21 @@ contains
 
           if(trim(specific_energy_type) == 'additional') then
              allocate(specific_energy_additional(geo%n_cells, n_dust))
-             if (compute_specific_energy_nu) then 
-                allocate(specific_energy_additional_nu(geo%n_cells,n_dust,n_nu_bins))
+             if (compute_specific_energy_spectrum) then 
+                allocate(specific_energy_additional_spectrum(geo%n_cells,n_dust,n_nu_bins))
              end if
              ! We store a copy of the initial specific energy in a separate
              ! array, and we set the specific energy to the minimum specific
              ! energy. After the first iteration, specific_energy will get
              ! re-calculated and we will then add specific_energy_additional
              specific_energy_additional = specific_energy
-             specific_energy_additional_nu = specific_energy_nu
+             specific_energy_additional_spectrum = specific_energy_spectrum
              do id=1,n_dust
                 specific_energy(:,id) = minimum_specific_energy(id)
                 
-                if (compute_specific_energy_nu) then
+                if (compute_specific_energy_spectrum) then
                    do idx=1,n_nu_bins
-                      specific_energy_nu(:,id,idx) = minimum_specific_energy(id)
+                      specific_energy_spectrum(:,id,idx) = minimum_specific_energy(id)
                    end do
                 end if
 
@@ -220,9 +220,9 @@ contains
           do id=1,n_dust
              specific_energy(:,id) = minimum_specific_energy(id)
 
-             if (compute_specific_energy_nu) then
+             if (compute_specific_energy_spectrum) then
                 do idx = 1,n_nu_bins
-                   specific_energy_nu(:,id,idx) = minimum_specific_energy(id)
+                   specific_energy_spectrum(:,id,idx) = minimum_specific_energy(id)
                 end do
              end if
 
@@ -240,16 +240,16 @@ contains
     specific_energy_sum = 0._dp
 
     ! Set up basics for the frequency-resolved specific energy
-    allocate(specific_energy_sum_nu(geo%n_cells, n_dust, n_nu_bins))
-    specific_energy_sum_nu = 0._dp
+    allocate(specific_energy_sum_spectrum(geo%n_cells, n_dust, n_nu_bins))
+    specific_energy_sum_spectrum = 0._dp
 
     ! Cache the frequency grid (and its log) once so they do not have to be
     ! rebuilt for every photon. Photons are binned to the nearest grid point in
     ! log-frequency space (see grid_propagate).
-    if (compute_specific_energy_nu) then
+    if (compute_specific_energy_spectrum) then
        allocate(nu_bins(n_nu_bins))
-       if (allocated(specific_energy_nu_frequencies)) then
-          nu_bins = specific_energy_nu_frequencies
+       if (allocated(specific_energy_spectrum_frequencies)) then
+          nu_bins = specific_energy_spectrum_frequencies
        else
           do idx=1,n_nu_bins
              nu_bins(idx) = d(1)%nu(idx)
@@ -327,7 +327,7 @@ contains
     integer :: reset
     integer :: n_nu_bins
 
-    n_nu_bins = size(specific_energy_nu, 3)
+    n_nu_bins = size(specific_energy_spectrum, 3)
 
     reset = 0
 
@@ -342,9 +342,9 @@ contains
                 specific_energy(ic, id) = minimum_specific_energy(id)
                 reset = reset + 1
 
-                if (compute_specific_energy_nu) then
+                if (compute_specific_energy_spectrum) then
                    do idx=1,n_nu_bins
-                      specific_energy_nu(ic,id,idx) = minimum_specific_energy(id)
+                      specific_energy_spectrum(ic,id,idx) = minimum_specific_energy(id)
                    end do
                 end if
 
@@ -365,9 +365,9 @@ contains
                 reset = reset + 1
 
 
-                if (compute_specific_energy_nu) then
+                if (compute_specific_energy_spectrum) then
                    do idx=1,n_nu_bins
-                      specific_energy_nu(ic,id,idx) = minimum_specific_energy(id)
+                      specific_energy_spectrum(ic,id,idx) = minimum_specific_energy(id)
                    end do
                 end if
                    
@@ -385,9 +385,9 @@ contains
              end if
 
              
-             if (compute_specific_energy_nu) then
+             if (compute_specific_energy_spectrum) then
                 do idx=1,n_nu_bins
-                   specific_energy_nu(ic,id,idx) = minimum_specific_energy(id)
+                   specific_energy_spectrum(ic,id,idx) = minimum_specific_energy(id)
                 end do
              end if
 
@@ -414,16 +414,16 @@ contains
     integer :: id,idx
     integer :: n_nu_bins
 
-    n_nu_bins = size(specific_energy_nu, 3)
+    n_nu_bins = size(specific_energy_spectrum, 3)
 
     if(main_process()) write(*,'(" [grid_physics] updating energy_abs")')
 
     do id=1,n_dust
        specific_energy(:,id) = specific_energy_sum(:,id) * scale / geo%volume
        
-       if (compute_specific_energy_nu) then
+       if (compute_specific_energy_spectrum) then
           do idx=1,n_nu_bins
-             specific_energy_nu(:,id,idx) = specific_energy_sum_nu(:,id,idx) * scale/geo%volume
+             specific_energy_spectrum(:,id,idx) = specific_energy_sum_spectrum(:,id,idx) * scale/geo%volume
           end do
        end if
           
@@ -444,8 +444,8 @@ contains
        specific_energy = specific_energy + specific_energy_additional
 
        
-       if (compute_specific_energy_nu) then 
-          specific_energy_nu = specific_energy_nu + specific_energy_additional_nu
+       if (compute_specific_energy_spectrum) then 
+          specific_energy_spectrum = specific_energy_spectrum + specific_energy_additional_spectrum
        end if
 
     end if

--- a/src/grid/grid_propagate_3d.f90
+++ b/src/grid/grid_propagate_3d.f90
@@ -10,7 +10,6 @@ module grid_propagate
   use counters
   use settings, only : frac_check => propagation_check_frequency, compute_isrf
 
-  !DN CRAZY ADDITIONS
   use grid_geometry, only : geo
 
   implicit none
@@ -60,8 +59,6 @@ contains
 
     integer :: source_id
 
-
-    !DN CRAZY ADDITIONS
     integer :: idx
     real, dimension(d(1)%n_nu) :: energy_frequency_bins
 
@@ -144,7 +141,8 @@ contains
           p%r = p%r + tmin * p%v
           tau_achieved = tau_achieved + tau_cell
 
-          !DN CRAZY ADDITIONS
+
+          ! Compute the ISRF 
           if (compute_isrf) then 
 
              idx = minloc(abs(energy_frequency_bins-p%nu),DIM=1)
@@ -158,7 +156,6 @@ contains
                 end if
                 
                 
-                !DN CRAZY ADDITIONS
                 if(density(p%icell%ic,id) > 0._dp) then
                    specific_energy_sum_nu(p%icell%ic,id,idx) = &
                         & specific_energy_sum_nu(p%icell%ic,id,idx) + tmin * p%current_kappa(id) * p%energy
@@ -250,7 +247,6 @@ contains
 
     integer :: source_id
 
-    !DN CRAZY ADDITIONS
     integer :: id
     integer :: idx
     real, dimension(d(0)%n_nu) :: energy_frequency_bins
@@ -309,20 +305,14 @@ contains
        chi_rho_total = 0._dp
 
 
-       
-       !DN CRAZY ADDITIONS
-       !idx = minloc(abs(energy_frequency_bins-p%nu),DIM=1)
-       !print *,'[grid_propagate_3d last iteration] p%energy=',p%energy
-       !print *,'[grid_propagate_3d last iteration] p%nu=',p%nu
-       !print *, "shape(specific_energy_sum_nu", shape(specific_energy_sum_nu)
+       !Compute the ISRF
 
-
+       !Figure out what frequency bin in the ISRF calculation the current photon's frequency is closest to
        idx = minloc(abs(energy_frequency_bins-p%nu),DIM=1)
 
        do id=1,n_dust
           chi_rho_total = chi_rho_total + p%current_chi(id) * density(p%icell%ic, id)
 
-          !DN CRAZY ADDITIONS
           if(density(p%icell%ic,id) > 0._dp) then
              specific_energy_sum_nu(p%icell%ic,id,idx) = &
                   & specific_energy_sum_nu(p%icell%ic,id,idx) + tmin * p%current_kappa(id) * p%energy

--- a/src/grid/grid_propagate_3d.f90
+++ b/src/grid/grid_propagate_3d.f90
@@ -3,7 +3,7 @@ module grid_propagate
   use core_lib
   use type_photon, only : photon
   use type_grid_cell
-  use dust_main, only : n_dust
+  use dust_main, only : n_dust,d
   use grid_geometry, only : escaped, find_wall, in_correct_cell, next_cell, opposite_wall
   use grid_physics, only : specific_energy_sum, specific_energy_sum_nu, density, n_photons, last_photon_id
   use sources
@@ -63,19 +63,14 @@ contains
 
     !DN CRAZY ADDITIONS
     integer :: idx
-    real, dimension(10) :: energy_frequency_bins
-    energy_frequency_bins(1) = 10.**14.4768207
-    energy_frequency_bins(2) = 10.**14.59237683
-    energy_frequency_bins(3) = 10.**14.70793296
-    energy_frequency_bins(4) = 10.**14.82348909
-    energy_frequency_bins(5) = 10.**14.93904522
-    energy_frequency_bins(6) = 10.**15.05460135
-    energy_frequency_bins(7) = 10.**15.17015748
-    energy_frequency_bins(8) = 10.**15.28571361
-    energy_frequency_bins(9) = 10.**15.40126974
-    energy_frequency_bins(10) = 10.**15.51682586
     
+    real, dimension(d(1)%n_nu) :: energy_frequency_bins
 
+    
+    do id=1,d(1)%n_nu
+       energy_frequency_bins(id) = d(1)%nu(id)
+    end do
+   
 
     radial = (p%r .dot. p%v) > 0.
 
@@ -163,10 +158,8 @@ contains
           idx = minloc(abs(energy_frequency_bins-p%nu),DIM=1)
 
 
-
-
-
           do id=1,n_dust
+
              if(density(p%icell%ic, id) > 0._dp) then
                 specific_energy_sum(p%icell%ic, id) = &
                      & specific_energy_sum(p%icell%ic, id) + tmin * p%current_kappa(id) * p%energy
@@ -266,20 +259,14 @@ contains
     integer :: source_id
 
     !DN CRAZY ADDITIONS
+    integer :: id
     integer :: idx
-    !DN CRAZY ADDITIONS
-    real, dimension(10) :: energy_frequency_bins
-    energy_frequency_bins(1) = 10.**14.4768207
-    energy_frequency_bins(2) = 10.**14.59237683
-    energy_frequency_bins(3) = 10.**14.70793296
-    energy_frequency_bins(4) = 10.**14.82348909
-    energy_frequency_bins(5) = 10.**14.93904522
-    energy_frequency_bins(6) = 10.**15.05460135
-    energy_frequency_bins(7) = 10.**15.17015748
-    energy_frequency_bins(8) = 10.**15.28571361
-    energy_frequency_bins(9) = 10.**15.40126974
-    energy_frequency_bins(10) = 10.**15.51682586
+    real, dimension(d(0)%n_nu) :: energy_frequency_bins
 
+    do id=1,d(0)%n_nu
+       energy_frequency_bins(id) = d(0)%nu(id)
+       print *,'[grid_propagate_3d last iteration] energy_frequency_bins(id) = ',energy_frequency_bins(id)
+    end do
 
     radial = (p%r .dot. p%v) > 0.
 

--- a/src/grid/grid_propagate_3d.f90
+++ b/src/grid/grid_propagate_3d.f90
@@ -318,7 +318,7 @@ contains
           if(density(p%icell%ic,id) > 0._dp) then
              specific_energy_sum_nu(p%icell%ic,id,1) = &
                   & specific_energy_sum_nu(p%icell%ic,id,idx) + tmin * p%current_kappa(id) * p%energy
-             print *,'[grid_propage_3d last iteration] specific_energy_sum_nu=',specific_energy_sum_nu
+             !print *,'[grid_propage_3d last iteration] specific_energy_sum_nu=',specific_energy_sum_nu
           end if
 
        end do

--- a/src/grid/grid_propagate_3d.f90
+++ b/src/grid/grid_propagate_3d.f90
@@ -10,6 +10,9 @@ module grid_propagate
   use counters
   use settings, only : frac_check => propagation_check_frequency
 
+  !DN CRAZY ADDITIONS
+  use grid_geometry, only : geo
+
   implicit none
   save
 
@@ -56,6 +59,23 @@ contains
     real(dp) :: xi
 
     integer :: source_id
+
+
+    !DN CRAZY ADDITIONS
+    integer :: idx
+    real, dimension(10) :: energy_frequency_bins
+    energy_frequency_bins(1) = 10.**14.4768207
+    energy_frequency_bins(2) = 10.**14.59237683
+    energy_frequency_bins(3) = 10.**14.70793296
+    energy_frequency_bins(4) = 10.**14.82348909
+    energy_frequency_bins(5) = 10.**14.93904522
+    energy_frequency_bins(6) = 10.**15.05460135
+    energy_frequency_bins(7) = 10.**15.17015748
+    energy_frequency_bins(8) = 10.**15.28571361
+    energy_frequency_bins(9) = 10.**15.40126974
+    energy_frequency_bins(10) = 10.**15.51682586
+    
+
 
     radial = (p%r .dot. p%v) > 0.
 
@@ -140,21 +160,27 @@ contains
           !print *,' ',minloc(abs(energy_frequency_bins-p%nu))
           
           !DN CRAZY ADDITIONS
-          !idx = minloc(abs(energy_frequency_bins-p%nu),DIM=1)
+          idx = minloc(abs(energy_frequency_bins-p%nu),DIM=1)
+
+
+
+
 
           do id=1,n_dust
              if(density(p%icell%ic, id) > 0._dp) then
                 specific_energy_sum(p%icell%ic, id) = &
                      & specific_energy_sum(p%icell%ic, id) + tmin * p%current_kappa(id) * p%energy
              end if
+             
+             
+             !DN CRAZY ADDITIONS
+             if(density(p%icell%ic,id) > 0._dp) then
+                specific_energy_sum_nu(p%icell%ic,id,idx) = &
+                     & specific_energy_sum_nu(p%icell%ic,id,idx) + tmin * p%current_kappa(id) * p%energy
+             end if
 
-             !if(density(p%icell%ic,id) > 0._dp) then
 
 
-             !specific_energy_sum_nu(p%icell%ic,id,1) = &
-             !        & specific_energy_sum_nu(p%icell%ic,id,idx) + tmin * p%current_kappa(id) * p%energy
-
-             !end if
           end do
 
           p%on_wall = .true.
@@ -309,6 +335,9 @@ contains
        !idx = minloc(abs(energy_frequency_bins-p%nu),DIM=1)
        !print *,'[grid_propagate_3d last iteration] p%energy=',p%energy
        !print *,'[grid_propagate_3d last iteration] p%nu=',p%nu
+       !print *, "shape(specific_energy_sum_nu", shape(specific_energy_sum_nu)
+
+
        idx = minloc(abs(energy_frequency_bins-p%nu),DIM=1)
 
        do id=1,n_dust
@@ -316,9 +345,9 @@ contains
 
           !DN CRAZY ADDITIONS
           if(density(p%icell%ic,id) > 0._dp) then
-             specific_energy_sum_nu(p%icell%ic,id,1) = &
+             specific_energy_sum_nu(p%icell%ic,id,idx) = &
                   & specific_energy_sum_nu(p%icell%ic,id,idx) + tmin * p%current_kappa(id) * p%energy
-             !print *,'[grid_propage_3d last iteration] specific_energy_sum_nu=',specific_energy_sum_nu
+             !print *,'[grid_propage_3d last iteration] specific_energy_sum_nu=',specific_energy_sum_nu(p%icell%ic,id,idx)
           end if
 
        end do

--- a/src/grid/grid_propagate_3d.f90
+++ b/src/grid/grid_propagate_3d.f90
@@ -249,11 +249,11 @@ contains
 
     integer :: id
     integer :: idx
-    real, dimension(d(0)%n_nu) :: energy_frequency_bins
+    real, dimension(d(1)%n_nu) :: energy_frequency_bins
 
-    do id=1,d(0)%n_nu
-       energy_frequency_bins(id) = d(0)%nu(id)
-       print *,'[grid_propagate_3d last iteration] energy_frequency_bins(id) = ',energy_frequency_bins(id)
+    do id=1,d(1)%n_nu
+       energy_frequency_bins(id) = d(1)%nu(id)
+       !print *,'[grid_propagate_3d last iteration] energy_frequency_bins(id) = ',energy_frequency_bins(id)
     end do
 
     radial = (p%r .dot. p%v) > 0.

--- a/src/grid/grid_propagate_3d.f90
+++ b/src/grid/grid_propagate_3d.f90
@@ -142,26 +142,18 @@ contains
           tau_achieved = tau_achieved + tau_cell
 
 
-          ! Compute the ISRF 
-          if (compute_isrf) then 
+          if (compute_isrf) idx = minloc(abs(energy_frequency_bins - p%nu), DIM=1)
 
-             idx = minloc(abs(energy_frequency_bins-p%nu),DIM=1)
-
-             
-             do id=1,n_dust
-                
-                if(density(p%icell%ic, id) > 0._dp) then
-                   specific_energy_sum(p%icell%ic, id) = &
-                        & specific_energy_sum(p%icell%ic, id) + tmin * p%current_kappa(id) * p%energy
+          do id=1,n_dust
+             if(density(p%icell%ic, id) > 0._dp) then
+                specific_energy_sum(p%icell%ic, id) = &
+                     & specific_energy_sum(p%icell%ic, id) + tmin * p%current_kappa(id) * p%energy
+                if (compute_isrf) then
+                   specific_energy_sum_nu(p%icell%ic, id, idx) = &
+                        & specific_energy_sum_nu(p%icell%ic, id, idx) + tmin * p%current_kappa(id) * p%energy
                 end if
-                
-                
-                if(density(p%icell%ic,id) > 0._dp) then
-                   specific_energy_sum_nu(p%icell%ic,id,idx) = &
-                        & specific_energy_sum_nu(p%icell%ic,id,idx) + tmin * p%current_kappa(id) * p%energy
-                end if
-             end do
-          endif
+             end if
+          end do
 
 
 

--- a/src/grid/grid_propagate_3d.f90
+++ b/src/grid/grid_propagate_3d.f90
@@ -5,10 +5,10 @@ module grid_propagate
   use type_grid_cell
   use dust_main, only : n_dust
   use grid_geometry, only : escaped, find_wall, in_correct_cell, next_cell, opposite_wall
-  use grid_physics, only : specific_energy_sum, specific_energy_sum_nu, log_nu_bins, density, n_photons, last_photon_id
+  use grid_physics, only : specific_energy_sum, specific_energy_sum_spectrum, log_nu_bins, density, n_photons, last_photon_id
   use sources
   use counters
-  use settings, only : frac_check => propagation_check_frequency, compute_specific_energy_nu
+  use settings, only : frac_check => propagation_check_frequency, compute_specific_energy_spectrum
 
   implicit none
   save
@@ -133,15 +133,15 @@ contains
           tau_achieved = tau_achieved + tau_cell
 
 
-          if (compute_specific_energy_nu) idx = minloc(abs(log_nu_bins - log10(p%nu)), DIM=1)
+          if (compute_specific_energy_spectrum) idx = minloc(abs(log_nu_bins - log10(p%nu)), DIM=1)
 
           do id=1,n_dust
              if(density(p%icell%ic, id) > 0._dp) then
                 specific_energy_sum(p%icell%ic, id) = &
                      & specific_energy_sum(p%icell%ic, id) + tmin * p%current_kappa(id) * p%energy
-                if (compute_specific_energy_nu) then
-                   specific_energy_sum_nu(p%icell%ic, id, idx) = &
-                        & specific_energy_sum_nu(p%icell%ic, id, idx) + tmin * p%current_kappa(id) * p%energy
+                if (compute_specific_energy_spectrum) then
+                   specific_energy_sum_spectrum(p%icell%ic, id, idx) = &
+                        & specific_energy_sum_spectrum(p%icell%ic, id, idx) + tmin * p%current_kappa(id) * p%energy
                 end if
              end if
           end do

--- a/src/grid/grid_propagate_3d.f90
+++ b/src/grid/grid_propagate_3d.f90
@@ -5,10 +5,10 @@ module grid_propagate
   use type_grid_cell
   use dust_main, only : n_dust
   use grid_geometry, only : escaped, find_wall, in_correct_cell, next_cell, opposite_wall
-  use grid_physics, only : specific_energy_sum, specific_energy_sum_nu, log_isrf_nu, density, n_photons, last_photon_id
+  use grid_physics, only : specific_energy_sum, specific_energy_sum_nu, log_nu_bins, density, n_photons, last_photon_id
   use sources
   use counters
-  use settings, only : frac_check => propagation_check_frequency, compute_isrf
+  use settings, only : frac_check => propagation_check_frequency, compute_specific_energy_nu
 
   implicit none
   save
@@ -133,13 +133,13 @@ contains
           tau_achieved = tau_achieved + tau_cell
 
 
-          if (compute_isrf) idx = minloc(abs(log_isrf_nu - log10(p%nu)), DIM=1)
+          if (compute_specific_energy_nu) idx = minloc(abs(log_nu_bins - log10(p%nu)), DIM=1)
 
           do id=1,n_dust
              if(density(p%icell%ic, id) > 0._dp) then
                 specific_energy_sum(p%icell%ic, id) = &
                      & specific_energy_sum(p%icell%ic, id) + tmin * p%current_kappa(id) * p%energy
-                if (compute_isrf) then
+                if (compute_specific_energy_nu) then
                    specific_energy_sum_nu(p%icell%ic, id, idx) = &
                         & specific_energy_sum_nu(p%icell%ic, id, idx) + tmin * p%current_kappa(id) * p%energy
                 end if

--- a/src/grid/grid_propagate_3d.f90
+++ b/src/grid/grid_propagate_3d.f90
@@ -60,13 +60,14 @@ contains
     integer :: source_id
 
     integer :: idx
-    real, dimension(d(1)%n_nu) :: energy_frequency_bins
+    real, allocatable :: energy_frequency_bins(:)
 
-    
-    do id=1,d(1)%n_nu
-       energy_frequency_bins(id) = d(1)%nu(id)
-    end do
-   
+    if (compute_isrf .and. n_dust > 0) then
+       allocate(energy_frequency_bins(d(1)%n_nu))
+       do id=1,d(1)%n_nu
+          energy_frequency_bins(id) = d(1)%nu(id)
+       end do
+    end if
 
     radial = (p%r .dot. p%v) > 0.
 
@@ -241,12 +242,14 @@ contains
 
     integer :: id
     integer :: idx
-    real, dimension(d(1)%n_nu) :: energy_frequency_bins
+    real, allocatable :: energy_frequency_bins(:)
 
-    do id=1,d(1)%n_nu
-       energy_frequency_bins(id) = d(1)%nu(id)
-       !print *,'[grid_propagate_3d last iteration] energy_frequency_bins(id) = ',energy_frequency_bins(id)
-    end do
+    if (compute_isrf .and. n_dust > 0) then
+       allocate(energy_frequency_bins(d(1)%n_nu))
+       do id=1,d(1)%n_nu
+          energy_frequency_bins(id) = d(1)%nu(id)
+       end do
+    end if
 
     radial = (p%r .dot. p%v) > 0.
 
@@ -296,19 +299,15 @@ contains
 
        chi_rho_total = 0._dp
 
-
-       !Compute the ISRF
-
-       !Figure out what frequency bin in the ISRF calculation the current photon's frequency is closest to
-       idx = minloc(abs(energy_frequency_bins-p%nu),DIM=1)
+       ! Figure out which ISRF frequency bin the current photon is closest to
+       if (compute_isrf) idx = minloc(abs(energy_frequency_bins - p%nu), DIM=1)
 
        do id=1,n_dust
           chi_rho_total = chi_rho_total + p%current_chi(id) * density(p%icell%ic, id)
 
-          if(density(p%icell%ic,id) > 0._dp) then
-             specific_energy_sum_nu(p%icell%ic,id,idx) = &
-                  & specific_energy_sum_nu(p%icell%ic,id,idx) + tmin * p%current_kappa(id) * p%energy
-             !print *,'[grid_propage_3d last iteration] specific_energy_sum_nu=',specific_energy_sum_nu(p%icell%ic,id,idx)
+          if (compute_isrf .and. density(p%icell%ic, id) > 0._dp) then
+             specific_energy_sum_nu(p%icell%ic, id, idx) = &
+                  & specific_energy_sum_nu(p%icell%ic, id, idx) + tmin * p%current_kappa(id) * p%energy
           end if
 
        end do

--- a/src/grid/grid_propagate_3d.f90
+++ b/src/grid/grid_propagate_3d.f90
@@ -5,7 +5,7 @@ module grid_propagate
   use type_grid_cell
   use dust_main, only : n_dust
   use grid_geometry, only : escaped, find_wall, in_correct_cell, next_cell, opposite_wall
-  use grid_physics, only : specific_energy_sum, specific_energy_sum_nu, isrf_nu, density, n_photons, last_photon_id
+  use grid_physics, only : specific_energy_sum, specific_energy_sum_nu, log_isrf_nu, density, n_photons, last_photon_id
   use sources
   use counters
   use settings, only : frac_check => propagation_check_frequency, compute_isrf
@@ -133,7 +133,7 @@ contains
           tau_achieved = tau_achieved + tau_cell
 
 
-          if (compute_isrf) idx = minloc(abs(isrf_nu - p%nu), DIM=1)
+          if (compute_isrf) idx = minloc(abs(log_isrf_nu - log10(p%nu)), DIM=1)
 
           do id=1,n_dust
              if(density(p%icell%ic, id) > 0._dp) then

--- a/src/grid/grid_propagate_3d.f90
+++ b/src/grid/grid_propagate_3d.f90
@@ -3,14 +3,12 @@ module grid_propagate
   use core_lib
   use type_photon, only : photon
   use type_grid_cell
-  use dust_main, only : n_dust,d
+  use dust_main, only : n_dust
   use grid_geometry, only : escaped, find_wall, in_correct_cell, next_cell, opposite_wall
-  use grid_physics, only : specific_energy_sum, specific_energy_sum_nu, density, n_photons, last_photon_id
+  use grid_physics, only : specific_energy_sum, specific_energy_sum_nu, isrf_nu, density, n_photons, last_photon_id
   use sources
   use counters
   use settings, only : frac_check => propagation_check_frequency, compute_isrf
-
-  use grid_geometry, only : geo
 
   implicit none
   save
@@ -60,14 +58,6 @@ contains
     integer :: source_id
 
     integer :: idx
-    real, allocatable :: energy_frequency_bins(:)
-
-    if (compute_isrf .and. n_dust > 0) then
-       allocate(energy_frequency_bins(d(1)%n_nu))
-       do id=1,d(1)%n_nu
-          energy_frequency_bins(id) = d(1)%nu(id)
-       end do
-    end if
 
     radial = (p%r .dot. p%v) > 0.
 
@@ -143,7 +133,7 @@ contains
           tau_achieved = tau_achieved + tau_cell
 
 
-          if (compute_isrf) idx = minloc(abs(energy_frequency_bins - p%nu), DIM=1)
+          if (compute_isrf) idx = minloc(abs(isrf_nu - p%nu), DIM=1)
 
           do id=1,n_dust
              if(density(p%icell%ic, id) > 0._dp) then
@@ -240,17 +230,6 @@ contains
 
     integer :: source_id
 
-    integer :: id
-    integer :: idx
-    real, allocatable :: energy_frequency_bins(:)
-
-    if (compute_isrf .and. n_dust > 0) then
-       allocate(energy_frequency_bins(d(1)%n_nu))
-       do id=1,d(1)%n_nu
-          energy_frequency_bins(id) = d(1)%nu(id)
-       end do
-    end if
-
     radial = (p%r .dot. p%v) > 0.
 
     if(debug) write(*,'(" [debug] start grid_integrate_noenergy")')
@@ -298,18 +277,8 @@ contains
        end if
 
        chi_rho_total = 0._dp
-
-       ! Figure out which ISRF frequency bin the current photon is closest to
-       if (compute_isrf) idx = minloc(abs(energy_frequency_bins - p%nu), DIM=1)
-
        do id=1,n_dust
           chi_rho_total = chi_rho_total + p%current_chi(id) * density(p%icell%ic, id)
-
-          if (compute_isrf .and. density(p%icell%ic, id) > 0._dp) then
-             specific_energy_sum_nu(p%icell%ic, id, idx) = &
-                  & specific_energy_sum_nu(p%icell%ic, id, idx) + tmin * p%current_kappa(id) * p%energy
-          end if
-
        end do
 
 

--- a/src/grid/grid_propagate_3d.f90
+++ b/src/grid/grid_propagate_3d.f90
@@ -195,6 +195,23 @@ contains
              end if
           end do
 
+          ! Deposit the same energy in the frequency-resolved spectrum.
+          ! Without this, the energy deposited over the partial path to
+          ! each interaction point is counted in the scalar specific
+          ! energy but missing from the binned spectrum, which biases
+          ! the spectrum low in any cell optically thick enough for
+          ! photons to interact within a single crossing.
+          if (compute_specific_energy_spectrum) then
+             idx = minloc(abs(log_nu_bins - log10(p%nu)), DIM=1)
+             do id=1,n_dust
+                if(density(p%icell%ic, id) > 0._dp) then
+                   specific_energy_sum_spectrum(p%icell%ic, id, idx) = &
+                        & specific_energy_sum_spectrum(p%icell%ic, id, idx) &
+                        & + tact * p%current_kappa(id) * p%energy
+                end if
+             end do
+          end if
+
           if(debug) write(*,'(" [debug] end grid_integrate")')
           return
 

--- a/src/main/settings.f90
+++ b/src/main/settings.f90
@@ -20,7 +20,7 @@ module settings
   integer(idp),public :: n_last_photons_dust = 0
   integer(idp),public :: n_raytracing_photons_sources = 0
   integer(idp),public :: n_raytracing_photons_dust = 0
-  logical,public :: use_raytracing, use_mrw, use_pda
+  logical,public :: use_raytracing, use_mrw, use_pda, compute_isrf
   logical, public :: kill_on_absorb, kill_on_scatter
   real(dp),public :: mrw_gamma
   logical, public :: forced_first_interaction

--- a/src/main/settings.f90
+++ b/src/main/settings.f90
@@ -20,7 +20,7 @@ module settings
   integer(idp),public :: n_last_photons_dust = 0
   integer(idp),public :: n_raytracing_photons_sources = 0
   integer(idp),public :: n_raytracing_photons_dust = 0
-  logical,public :: use_raytracing, use_mrw, use_pda, compute_specific_energy_nu
+  logical,public :: use_raytracing, use_mrw, use_pda, compute_specific_energy_spectrum
   logical, public :: kill_on_absorb, kill_on_scatter
   real(dp),public :: mrw_gamma
   logical, public :: forced_first_interaction
@@ -30,16 +30,16 @@ module settings
   real(dp) :: monochromatic_energy_threshold
   real(dp),allocatable :: frequencies(:)
 
-  ! Optional user-specified frequency grid for specific_energy_nu. If not
+  ! Optional user-specified frequency grid for specific_energy_spectrum. If not
   ! allocated, the frequency grid of the first dust type is used instead.
-  real(dp),allocatable :: specific_energy_nu_frequencies(:)
+  real(dp),allocatable :: specific_energy_spectrum_frequencies(:)
 
   integer :: physics_io_type
 
   character(len=4) :: output_density
   character(len=4) :: output_density_diff
   character(len=4) :: output_specific_energy
-  character(len=4) :: output_specific_energy_nu
+  character(len=4) :: output_specific_energy_spectrum
   character(len=4) :: output_n_photons
 
   logical :: check_convergence = .false.

--- a/src/main/settings.f90
+++ b/src/main/settings.f90
@@ -30,6 +30,10 @@ module settings
   real(dp) :: monochromatic_energy_threshold
   real(dp),allocatable :: frequencies(:)
 
+  ! Optional user-specified frequency grid for the ISRF. If not allocated, the
+  ! frequency grid of the first dust type is used instead.
+  real(dp),allocatable :: isrf_frequencies(:)
+
   integer :: physics_io_type
 
   character(len=4) :: output_density

--- a/src/main/settings.f90
+++ b/src/main/settings.f90
@@ -20,7 +20,7 @@ module settings
   integer(idp),public :: n_last_photons_dust = 0
   integer(idp),public :: n_raytracing_photons_sources = 0
   integer(idp),public :: n_raytracing_photons_dust = 0
-  logical,public :: use_raytracing, use_mrw, use_pda, compute_isrf
+  logical,public :: use_raytracing, use_mrw, use_pda, compute_specific_energy_nu
   logical, public :: kill_on_absorb, kill_on_scatter
   real(dp),public :: mrw_gamma
   logical, public :: forced_first_interaction
@@ -30,15 +30,16 @@ module settings
   real(dp) :: monochromatic_energy_threshold
   real(dp),allocatable :: frequencies(:)
 
-  ! Optional user-specified frequency grid for the ISRF. If not allocated, the
-  ! frequency grid of the first dust type is used instead.
-  real(dp),allocatable :: isrf_frequencies(:)
+  ! Optional user-specified frequency grid for specific_energy_nu. If not
+  ! allocated, the frequency grid of the first dust type is used instead.
+  real(dp),allocatable :: specific_energy_nu_frequencies(:)
 
   integer :: physics_io_type
 
   character(len=4) :: output_density
   character(len=4) :: output_density_diff
   character(len=4) :: output_specific_energy
+  character(len=4) :: output_specific_energy_nu
   character(len=4) :: output_n_photons
 
   logical :: check_convergence = .false.

--- a/src/main/setup_rt.f90
+++ b/src/main/setup_rt.f90
@@ -74,8 +74,6 @@ contains
 
     call mp_read_keyword(input_handle, '/', 'pda', use_pda)
     call mp_read_keyword(input_handle, '/', 'mrw', use_mrw)
-
-    !DN CRAZY ADDITIONS
     call mp_read_keyword(input_handle, '/', 'isrf', compute_isrf)
 
     if(use_mrw) then

--- a/src/main/setup_rt.f90
+++ b/src/main/setup_rt.f90
@@ -75,6 +75,9 @@ contains
     call mp_read_keyword(input_handle, '/', 'pda', use_pda)
     call mp_read_keyword(input_handle, '/', 'mrw', use_mrw)
 
+    !DN CRAZY ADDITIONS
+    call mp_read_keyword(input_handle, '/', 'isrf', compute_isrf)
+
     if(use_mrw) then
        call mp_read_keyword(input_handle, '/', 'mrw_gamma', mrw_gamma)
        call mp_read_keyword(input_handle, '/', 'n_inter_mrw_max', n_mrw_max)
@@ -173,7 +176,7 @@ contains
     call mp_close_group(g_geometry)
 
     g_physics = mp_open_group(input_handle, '/Grid/Quantities')
-    call setup_grid_physics(g_physics, use_mrw, use_pda)
+    call setup_grid_physics(g_physics, use_mrw, use_pda, compute_isrf)
     call mp_close_group(g_physics)
 
     call mp_read_keyword(input_handle, '/', 'physics_io_bytes', physics_io_bytes)

--- a/src/main/setup_rt.f90
+++ b/src/main/setup_rt.f90
@@ -75,28 +75,28 @@ contains
     call mp_read_keyword(input_handle, '/', 'pda', use_pda)
     call mp_read_keyword(input_handle, '/', 'mrw', use_mrw)
     ! The frequency-resolved specific energy is computed whenever it is to be
-    ! output, i.e. unless output_specific_energy_nu is 'none'. This is read here
+    ! output, i.e. unless output_specific_energy_spectrum is 'none'. This is read here
     ! (ahead of the main OUTPUT block below) because it is needed to set up the
     ! grid physics arrays.
     g_output = mp_open_group(input_handle, '/Output')
-    if(mp_exists_keyword(g_output, '.', 'output_specific_energy_nu')) then
-       call mp_read_keyword(g_output, '.', 'output_specific_energy_nu', output_specific_energy_nu)
+    if(mp_exists_keyword(g_output, '.', 'output_specific_energy_spectrum')) then
+       call mp_read_keyword(g_output, '.', 'output_specific_energy_spectrum', output_specific_energy_spectrum)
     else
-       output_specific_energy_nu = 'none'
+       output_specific_energy_spectrum = 'none'
     end if
     call mp_close_group(g_output)
 
-    if(trim(output_specific_energy_nu).ne.'all' &
-         & .and.trim(output_specific_energy_nu).ne.'last' &
-         & .and.trim(output_specific_energy_nu).ne.'none') &
-         & call error("setup_initial","output_specific_energy_nu should be one of all/last/none")
+    if(trim(output_specific_energy_spectrum).ne.'all' &
+         & .and.trim(output_specific_energy_spectrum).ne.'last' &
+         & .and.trim(output_specific_energy_spectrum).ne.'none') &
+         & call error("setup_initial","output_specific_energy_spectrum should be one of all/last/none")
 
-    compute_specific_energy_nu = trim(output_specific_energy_nu).ne.'none'
+    compute_specific_energy_spectrum = trim(output_specific_energy_spectrum).ne.'none'
 
     ! Optional user-specified frequency grid (otherwise the dust grid is used)
-    if(compute_specific_energy_nu) then
-       if(mp_path_exists(input_handle, 'specific_energy_nu_frequencies')) then
-          call mp_table_read_column_auto(input_handle, 'specific_energy_nu_frequencies', 'nu', specific_energy_nu_frequencies)
+    if(compute_specific_energy_spectrum) then
+       if(mp_path_exists(input_handle, 'specific_energy_spectrum_frequencies')) then
+          call mp_table_read_column_auto(input_handle, 'specific_energy_spectrum_frequencies', 'nu', specific_energy_spectrum_frequencies)
        end if
     end if
 
@@ -198,7 +198,7 @@ contains
     call mp_close_group(g_geometry)
 
     g_physics = mp_open_group(input_handle, '/Grid/Quantities')
-    call setup_grid_physics(g_physics, use_mrw, use_pda, compute_specific_energy_nu)
+    call setup_grid_physics(g_physics, use_mrw, use_pda, compute_specific_energy_spectrum)
     call mp_close_group(g_physics)
 
     call mp_read_keyword(input_handle, '/', 'physics_io_bytes', physics_io_bytes)

--- a/src/main/setup_rt.f90
+++ b/src/main/setup_rt.f90
@@ -74,12 +74,29 @@ contains
 
     call mp_read_keyword(input_handle, '/', 'pda', use_pda)
     call mp_read_keyword(input_handle, '/', 'mrw', use_mrw)
-    call mp_read_keyword(input_handle, '/', 'isrf', compute_isrf)
+    ! The frequency-resolved specific energy is computed whenever it is to be
+    ! output, i.e. unless output_specific_energy_nu is 'none'. This is read here
+    ! (ahead of the main OUTPUT block below) because it is needed to set up the
+    ! grid physics arrays.
+    g_output = mp_open_group(input_handle, '/Output')
+    if(mp_exists_keyword(g_output, '.', 'output_specific_energy_nu')) then
+       call mp_read_keyword(g_output, '.', 'output_specific_energy_nu', output_specific_energy_nu)
+    else
+       output_specific_energy_nu = 'none'
+    end if
+    call mp_close_group(g_output)
 
-    ! Optional user-specified ISRF frequency grid (otherwise the dust grid is used)
-    if(compute_isrf) then
-       if(mp_path_exists(input_handle, 'isrf_frequencies')) then
-          call mp_table_read_column_auto(input_handle, 'isrf_frequencies', 'nu', isrf_frequencies)
+    if(trim(output_specific_energy_nu).ne.'all' &
+         & .and.trim(output_specific_energy_nu).ne.'last' &
+         & .and.trim(output_specific_energy_nu).ne.'none') &
+         & call error("setup_initial","output_specific_energy_nu should be one of all/last/none")
+
+    compute_specific_energy_nu = trim(output_specific_energy_nu).ne.'none'
+
+    ! Optional user-specified frequency grid (otherwise the dust grid is used)
+    if(compute_specific_energy_nu) then
+       if(mp_path_exists(input_handle, 'specific_energy_nu_frequencies')) then
+          call mp_table_read_column_auto(input_handle, 'specific_energy_nu_frequencies', 'nu', specific_energy_nu_frequencies)
        end if
     end if
 
@@ -181,7 +198,7 @@ contains
     call mp_close_group(g_geometry)
 
     g_physics = mp_open_group(input_handle, '/Grid/Quantities')
-    call setup_grid_physics(g_physics, use_mrw, use_pda, compute_isrf)
+    call setup_grid_physics(g_physics, use_mrw, use_pda, compute_specific_energy_nu)
     call mp_close_group(g_physics)
 
     call mp_read_keyword(input_handle, '/', 'physics_io_bytes', physics_io_bytes)

--- a/src/main/setup_rt.f90
+++ b/src/main/setup_rt.f90
@@ -76,6 +76,13 @@ contains
     call mp_read_keyword(input_handle, '/', 'mrw', use_mrw)
     call mp_read_keyword(input_handle, '/', 'isrf', compute_isrf)
 
+    ! Optional user-specified ISRF frequency grid (otherwise the dust grid is used)
+    if(compute_isrf) then
+       if(mp_path_exists(input_handle, 'isrf_frequencies')) then
+          call mp_table_read_column_auto(input_handle, 'isrf_frequencies', 'nu', isrf_frequencies)
+       end if
+    end if
+
     if(use_mrw) then
        call mp_read_keyword(input_handle, '/', 'mrw_gamma', mrw_gamma)
        call mp_read_keyword(input_handle, '/', 'n_inter_mrw_max', n_mrw_max)

--- a/src/mpi/mpi_routines.f90
+++ b/src/mpi/mpi_routines.f90
@@ -266,6 +266,8 @@ contains
     real(dp) :: tmp
     real(dp) :: dummy_dp
     integer(idp) :: dummy_idp
+    !DN crazy additions
+    real(dp),allocatable :: tmp_3d(:,:,:)
     real(dp),allocatable :: tmp_2d(:,:)
     integer(idp),allocatable :: tmp_int_1d(:)
 
@@ -277,6 +279,17 @@ contains
     else
        call mpi_reduce(specific_energy_sum, dummy_dp, size(specific_energy_sum), mpi_real8, mpi_sum, rank_main, mpi_comm_world, ierr)
     end if
+
+    if(main_process()) then
+       allocate(tmp_3d(size(specific_energy_sum_nu,1),size(specific_energy_sum_nu,2),size(specific_energy_sum_nu,3)))
+       call mpi_reduce(specific_energy_sum_nu, tmp_3d, size(specific_energy_sum_nu), mpi_real8, mpi_sum, rank_main, mpi_comm_world, ierr)
+       specific_energy_sum_nu = tmp_3d
+       deallocate(tmp_3d)
+    else
+       call mpi_reduce(specific_energy_sum_nu, dummy_dp, size(specific_energy_sum_nu), mpi_real8, mpi_sum, rank_main, mpi_comm_world, ierr)
+    end if
+
+
 
     if(allocated(n_photons)) then
        if(main_process()) then

--- a/src/mpi/mpi_routines.f90
+++ b/src/mpi/mpi_routines.f90
@@ -266,7 +266,7 @@ contains
     real(dp) :: tmp
     real(dp) :: dummy_dp
     integer(idp) :: dummy_idp
-    !DN crazy additions
+
     real(dp),allocatable :: tmp_3d(:,:,:)
     real(dp),allocatable :: tmp_2d(:,:)
     integer(idp),allocatable :: tmp_int_1d(:)

--- a/src/mpi/mpi_routines.f90
+++ b/src/mpi/mpi_routines.f90
@@ -289,8 +289,6 @@ contains
        call mpi_reduce(specific_energy_sum_nu, dummy_dp, size(specific_energy_sum_nu), mpi_real8, mpi_sum, rank_main, mpi_comm_world, ierr)
     end if
 
-
-
     if(allocated(n_photons)) then
        if(main_process()) then
           allocate(tmp_int_1d(size(n_photons,1)))

--- a/src/mpi/mpi_routines.f90
+++ b/src/mpi/mpi_routines.f90
@@ -281,12 +281,12 @@ contains
     end if
 
     if(main_process()) then
-       allocate(tmp_3d(size(specific_energy_sum_nu,1),size(specific_energy_sum_nu,2),size(specific_energy_sum_nu,3)))
-       call mpi_reduce(specific_energy_sum_nu, tmp_3d, size(specific_energy_sum_nu), mpi_real8, mpi_sum, rank_main, mpi_comm_world, ierr)
-       specific_energy_sum_nu = tmp_3d
+       allocate(tmp_3d(size(specific_energy_sum_spectrum,1),size(specific_energy_sum_spectrum,2),size(specific_energy_sum_spectrum,3)))
+       call mpi_reduce(specific_energy_sum_spectrum, tmp_3d, size(specific_energy_sum_spectrum), mpi_real8, mpi_sum, rank_main, mpi_comm_world, ierr)
+       specific_energy_sum_spectrum = tmp_3d
        deallocate(tmp_3d)
     else
-       call mpi_reduce(specific_energy_sum_nu, dummy_dp, size(specific_energy_sum_nu), mpi_real8, mpi_sum, rank_main, mpi_comm_world, ierr)
+       call mpi_reduce(specific_energy_sum_spectrum, dummy_dp, size(specific_energy_sum_spectrum), mpi_real8, mpi_sum, rank_main, mpi_comm_world, ierr)
     end if
 
     if(allocated(n_photons)) then


### PR DESCRIPTION
the upshot is that by setting in the python code:

```m.compute_isrf(True)```

hyperion will save the spectrum of energy deposited in every cell.     this can be accessed in the hdf5 file via:

```
import numpy as np
import h5py

f = h5py.File('pd_skirt_comparison.134.rtout.sed')
dset = f['iteration_00007']
print(np.max(dset['specific_energy_sum_nu']))
print(dset['ISRF_frequency_bins'][:])
```
where the units are erg/s/g (and the "g" is the dust mass in the cell).

this, however, doesn't work for AMR grids because I'm having trouble understanding the file structure, and am unable to get the code to compile. As a result, I'm labeling this PR as a work in progress, and happy to iterate on this.  Two main areas I could use eyes from @astrofrog are is:

1. accuracy of code!
2. if #1 is okay, then to see by analogy how to update the AMR code in the fortran modules