### PR TITLE
Remove code related to wall shapes in voro++ wrapper since it is not used

### DIFF
--- a/hyperion/grid/_voronoi_core.c
+++ b/hyperion/grid/_voronoi_core.c
@@ -56,33 +56,18 @@ static PyObject *_voropp_wrapper(PyObject *self, PyObject *args)
 {
     PyObject *sites_obj, *domain_obj, *wall_args_obj;
     int with_vertices;
-    const char *wall_str;
+    const char *wall_str = "";
     int verbose;
     int with_sampling, n_samples, min_cell_samples, seed;
 
-    if (!PyArg_ParseTuple(args, "OOisOiiiii", &sites_obj, &domain_obj, &with_vertices,&wall_str,&wall_args_obj,
+    if (!PyArg_ParseTuple(args, "OOiiiiii", &sites_obj, &domain_obj, &with_vertices,
         &with_sampling, &n_samples, &min_cell_samples, &seed, &verbose))
     {
         return NULL;
     }
 
-    // Handle the wall-related arguments.
-    // NOTE: at the moment, the walls implemented in voro++ have at most 7 doubles as construction params.
     double wall_args_arr[7];
-    // The actual number of construction arguments.
-    int n_wall_args = (int)PyTuple_GET_SIZE(wall_args_obj);
-    if (n_wall_args > 7) {
-        PyErr_SetString(PyExc_TypeError, "Too many construction arguments for the wall object.");
-        return NULL;
-    }
-    {
-        // Read the wall construction arguments.
-        int i;
-        for (i = 0; i < n_wall_args; ++i) {
-            // NOTE: PyTuple_GetItem returns a borrowed reference, no need to handle refcount.
-            wall_args_arr[i] = PyFloat_AS_DOUBLE(PyTuple_GetItem(wall_args_obj,(Py_ssize_t)i));
-        }
-    }
+    int n_wall_args = 0;
 
     /* Interpret the input objects as `numpy` arrays. */
     PyObject *s_array = PyArray_FROM_OTF(sites_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);

--- a/hyperion/grid/voronoi_helpers.py
+++ b/hyperion/grid/voronoi_helpers.py
@@ -47,20 +47,10 @@ class voronoi_grid(object):
         The vertices of the cells are not needed for RT simulations,
         and they add a considerable overhead in terms of memory requirements.
         Required for plotting and useful for debugging.
-    wall : a string or ``None``
-        If not ``None``, it must be one of
-        ``['sphere','cylinder','cone','plane']``. It will define an additional
-        wall of the desired shape within the domain.
-    wall_args : a tuple of floats or ``None``
-        Meaningful only if ``wall`` is not None, it represents the parameters
-        to be used to construct the wall (e.g., in case of a spherical wall,
-        the centre position and the radius of the sphere). Different construction
-        arguments are required for different types of wall, see the voro++
-        documentation for more information.
     '''
 
     def __init__(self, sites, domain, n_samples=0, min_cell_samples=10, with_vertices=False,
-                 wall=None, wall_args=None, verbose=False, seed=0):
+                 verbose=False, seed=0):
         import numpy as np
         from ._voronoi_core import _voropp_wrapper
         from astropy.table import Table
@@ -101,28 +91,18 @@ class voronoi_grid(object):
         if not isinstance(min_cell_samples, int) or min_cell_samples < 0:
             raise TypeError(
                 'the \'min_cell_samples\' parameter must be a non-negative int')
-        # Wall checks.
-        allowed_walls = ['sphere', 'cylinder', 'cone', 'plane']
-        if not wall is None and not wall in allowed_walls:
-            raise ValueError('the \'wall\' parameter must be None or one of ' + str(allowed_walls))
-        if not wall_args is None and (not isinstance(wall_args, tuple) or not all([isinstance(_, float) for _ in wall_args])):
-            raise ValueError('the \'wall_args\' parameter must be None or a tuple of floats')
         # Seed checks.
         if not isinstance(seed, int):
             raise TypeError(
                 'the \'seed\' parameter must be an int')
         self._seed = seed
 
-        # Redefine wall params in order to pass it to the C++ routine.
-        wall = "" if wall is None else wall
-        wall_args = () if wall_args is None else wall_args
-
         # Store the vertices flag.
         self._with_vertices = with_vertices
 
         logger.info("Computing the tessellation via voro++")
         with_sampling = 1 if n_samples > 0 else 0
-        tup = _voropp_wrapper(sites, domain, with_vertices, wall, wall_args, with_sampling, n_samples,
+        tup = _voropp_wrapper(sites, domain, with_vertices, with_sampling, n_samples,
                               min_cell_samples, seed, 1 if verbose else 0)
         names = ['coordinates', 'volume', 'bb_min', 'bb_max']
         if with_vertices:

--- a/hyperion/grid/voropp_wrap.cc
+++ b/hyperion/grid/voropp_wrap.cc
@@ -66,54 +66,6 @@ static inline bool size_cmp(const std::vector<T> &a, const std::vector<T> &b)
 // Global string used for reporting errors back to Python.
 static std::string error_message;
 
-// Wall utilities.
-// Need to store this statically as the wall object needs to exist outside the scope
-// in which it is created.
-static std::auto_ptr<wall> wall_ptr;
-
-// Helper function to add the wall.
-static inline void add_walls(container &con,const char *wall_str,const double *wall_args_arr,int n_wall_args,int verbose)
-{
-    if (verbose) {
-        std::cout << "Wall type: " << wall_str << '\n';
-        std::cout << "Wall number of args: " << n_wall_args << '\n';
-        std::cout << "Wall params: [";
-        for (int i = 0; i < n_wall_args; ++i) {
-            std::cout << wall_args_arr[i];
-            if (i != n_wall_args - 1) {
-                std::cout << ',';
-            }
-        }
-        std::cout << "]\n";
-    }
-
-    // Allowed walls: 'sphere','cylinder','cone','plane'.
-    if (std::strcmp(wall_str,"sphere") == 0) {
-        // Some checks.
-        if (n_wall_args != 4) {
-            throw std::invalid_argument("invalid number of arguments for a 'sphere' wall, exactly 4 are needed");
-        }
-        if (wall_args_arr[3] <= 0.) {
-            throw std::invalid_argument("the radius of a 'sphere' wall must be strictly positive");
-        }
-        wall_ptr.reset(new wall_sphere(wall_args_arr[0],wall_args_arr[1],wall_args_arr[2],wall_args_arr[3]));
-        con.add_wall(wall_ptr.get());
-    }
-    if (std::strcmp(wall_str,"cylinder") == 0) {
-        // Some checks.
-        if (n_wall_args != 7) {
-            throw std::invalid_argument("invalid number of arguments for a 'cylinder' wall, exactly 7 are needed");
-        }
-        if (wall_args_arr[6] <= 0.) {
-            throw std::invalid_argument("the radius of a 'cylinder' wall must be strictly positive");
-        }
-        wall_ptr.reset(new wall_cylinder(wall_args_arr[0],wall_args_arr[1],wall_args_arr[2],wall_args_arr[3],wall_args_arr[4],
-            wall_args_arr[5],wall_args_arr[6]
-        ));
-        con.add_wall(wall_ptr.get());
-    }
-}
-
 // Compute the volume of a tetrahedron.
 template <typename It>
 static inline double tetra_volume(It v0, It v1, It v2, It v3)
@@ -226,9 +178,6 @@ const char *hyperion_voropp_wrap(int **sparse_neighbours, int **neigh_pos, int *
     for(int i = 0; i < nsites; ++i) {
             con.put(i,points[i*3],points[i*3 + 1],points[i*3 + 2]);
     }
-
-    // Handle the walls.
-    add_walls(con,wall_str,wall_args_arr,n_wall_args,verbose);
 
     // Initialise the looping variables and the temporary cell object used for computation.
     voronoicell_neighbor c;


### PR DESCRIPTION
This code ends up being not compatible with the limited API and not used anyway so might as well simply things.