### PR TITLE
Get rid of MPI compilation warnings

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -61,7 +61,8 @@ OBJECTS_CAR_SER =	src/mpi/mpi_core_nompi.f90 \
 			src/mpi/mpi_routines_nompi.f90 \
 			$(OBJECTS3)
 
-OBJECTS_CAR_MPI =	src/mpi/mpi_core.f90 \
+OBJECTS_CAR_MPI =	src/mpi/mpi_interfaces.f90 \
+			src/mpi/mpi_core.f90 \
 			fortranlib/src/@posix_module_mpi@.f90 \
 			$(COMMON) \
 			src/core/core_lib.f90 \
@@ -95,7 +96,8 @@ OBJECTS_AMR_SER =	src/mpi/mpi_core_nompi.f90 \
 			src/mpi/mpi_routines_nompi.f90 \
 			$(OBJECTS3)
 
-OBJECTS_AMR_MPI =	src/mpi/mpi_core.f90 \
+OBJECTS_AMR_MPI =	src/mpi/mpi_interfaces.f90 \
+			src/mpi/mpi_core.f90 \
 			fortranlib/src/@posix_module_mpi@.f90 \
 			$(COMMON) \
 			src/core/core_lib.f90 \
@@ -129,7 +131,8 @@ OBJECTS_OCT_SER =	src/mpi/mpi_core_nompi.f90 \
 			src/mpi/mpi_routines_nompi.f90 \
 			$(OBJECTS3)
 
-OBJECTS_OCT_MPI =	src/mpi/mpi_core.f90 \
+OBJECTS_OCT_MPI =	src/mpi/mpi_interfaces.f90 \
+			src/mpi/mpi_core.f90 \
 			fortranlib/src/@posix_module_mpi@.f90 \
 			$(COMMON) \
 			src/core/core_lib.f90 \
@@ -164,7 +167,8 @@ OBJECTS_VOR_SER =	src/mpi/mpi_core_nompi.f90 \
 			src/mpi/mpi_routines_nompi.f90 \
 			$(OBJECTS3)
 
-OBJECTS_VOR_MPI =	src/mpi/mpi_core.f90 \
+OBJECTS_VOR_MPI =	src/mpi/mpi_interfaces.f90 \
+			src/mpi/mpi_core.f90 \
 			fortranlib/src/@posix_module_mpi@.f90 \
 			$(COMMON) \
 			src/extern/kdtree2/kdtree2.f90 \
@@ -199,7 +203,8 @@ OBJECTS_SPH_SER =	src/mpi/mpi_core_nompi.f90 \
 			src/mpi/mpi_routines_nompi.f90 \
 			$(OBJECTS3)
 
-OBJECTS_SPH_MPI =	src/mpi/mpi_core.f90 \
+OBJECTS_SPH_MPI =	src/mpi/mpi_interfaces.f90 \
+			src/mpi/mpi_core.f90 \
 			fortranlib/src/@posix_module_mpi@.f90 \
 			$(COMMON) \
 			src/core/core_lib.f90 \
@@ -233,7 +238,8 @@ OBJECTS_CYL_SER =	src/mpi/mpi_core_nompi.f90 \
 			src/mpi/mpi_routines_nompi.f90 \
 			$(OBJECTS3)
 
-OBJECTS_CYL_MPI =	src/mpi/mpi_core.f90 \
+OBJECTS_CYL_MPI =	src/mpi/mpi_interfaces.f90 \
+			src/mpi/mpi_core.f90 \
 			fortranlib/src/@posix_module_mpi@.f90 \
 			$(COMMON) \
 			src/core/core_lib.f90 \

--- a/src/mpi/mpi_interfaces.f90
+++ b/src/mpi/mpi_interfaces.f90
@@ -1,0 +1,61 @@
+! Explicit interfaces for the MPI routines that take "choice" buffer
+! arguments (buffers that can be of any type and rank). The mpich "mpi"
+! module does not declare interfaces for these routines, so gfortran 10 and
+! later warns about every pair of calls to the same routine with buffers of
+! different types or ranks. The NO_ARG_CHECK attribute (supported by both
+! gfortran and the Intel compilers, and ignored as a comment by others)
+! reproduces the "ignore type, kind and rank" behaviour that MPI
+! implementations themselves use for choice buffers, while keeping the
+! non-buffer arguments type-checked.
+
+module mpi_interfaces
+
+  implicit none
+
+  interface
+
+     subroutine mpi_bcast(buffer, count, datatype, root, comm, ierror)
+       !GCC$ ATTRIBUTES NO_ARG_CHECK :: buffer
+       !DEC$ ATTRIBUTES NO_ARG_CHECK :: buffer
+       type(*) :: buffer(*)
+       integer :: count, datatype, root, comm, ierror
+     end subroutine mpi_bcast
+
+     subroutine mpi_reduce(sendbuf, recvbuf, count, datatype, op, root, comm, ierror)
+       !GCC$ ATTRIBUTES NO_ARG_CHECK :: sendbuf, recvbuf
+       !DEC$ ATTRIBUTES NO_ARG_CHECK :: sendbuf, recvbuf
+       type(*) :: sendbuf(*), recvbuf(*)
+       integer :: count, datatype, op, root, comm, ierror
+     end subroutine mpi_reduce
+
+     subroutine mpi_allreduce(sendbuf, recvbuf, count, datatype, op, comm, ierror)
+       !GCC$ ATTRIBUTES NO_ARG_CHECK :: sendbuf, recvbuf
+       !DEC$ ATTRIBUTES NO_ARG_CHECK :: sendbuf, recvbuf
+       type(*) :: sendbuf(*), recvbuf(*)
+       integer :: count, datatype, op, comm, ierror
+     end subroutine mpi_allreduce
+
+     subroutine mpi_recv(buf, count, datatype, source, tag, comm, status, ierror)
+       !GCC$ ATTRIBUTES NO_ARG_CHECK :: buf
+       !DEC$ ATTRIBUTES NO_ARG_CHECK :: buf
+       type(*) :: buf(*)
+       integer :: count, datatype, source, tag, comm, status(*), ierror
+     end subroutine mpi_recv
+
+     subroutine mpi_isend(buf, count, datatype, dest, tag, comm, request, ierror)
+       !GCC$ ATTRIBUTES NO_ARG_CHECK :: buf
+       !DEC$ ATTRIBUTES NO_ARG_CHECK :: buf
+       type(*) :: buf(*)
+       integer :: count, datatype, dest, tag, comm, request, ierror
+     end subroutine mpi_isend
+
+     subroutine mpi_irecv(buf, count, datatype, source, tag, comm, request, ierror)
+       !GCC$ ATTRIBUTES NO_ARG_CHECK :: buf
+       !DEC$ ATTRIBUTES NO_ARG_CHECK :: buf
+       type(*) :: buf(*)
+       integer :: count, datatype, source, tag, comm, request, ierror
+     end subroutine mpi_irecv
+
+  end interface
+
+end module mpi_interfaces

--- a/src/mpi/mpi_io.f90
+++ b/src/mpi/mpi_io.f90
@@ -1,8 +1,9 @@
-! MD5 of template: d391eca44de1bf600f23e91f9dab6ebf
+! MD5 of template: 1e1c708fb2055feec7cad222682bbe09
 module mpi_hdf5_io
 
   use core_lib
   use mpi
+  use mpi_interfaces
   use mpi_core
 
   implicit none

--- a/src/mpi/mpi_io_template.f90
+++ b/src/mpi/mpi_io_template.f90
@@ -2,6 +2,7 @@ module mpi_hdf5_io
 
   use core_lib
   use mpi
+  use mpi_interfaces
   use mpi_core
 
   implicit none

--- a/src/mpi/mpi_routines.f90
+++ b/src/mpi/mpi_routines.f90
@@ -1,6 +1,7 @@
 module mpi_routines
 
   use mpi
+  use mpi_interfaces
   use mpi_core
   use core_lib
   use grid_physics


### PR DESCRIPTION
These warnings appear during compilation:

```
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
src/mpi/mpi_io.f90:781:19:

  781 |     call mpi_bcast(array, n1*n2, mpi_integer4, rank_main, mpi_comm_world, ierr)
      |                   1
......
 1604 |     call mpi_bcast(n1, 1, mpi_integer4, rank_main, mpi_comm_world, ierr)
      |                   2
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-2)
src/mpi/mpi_io.f90:764:19:

  764 |     call mpi_bcast(array, n1, mpi_integer4, rank_main, mpi_comm_world, ierr)
      |                   1
......
 1604 |     call mpi_bcast(n1, 1, mpi_integer4, rank_main, mpi_comm_world, ierr)
      |                   2
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
src/mpi/mpi_io.f90:735:19:
```

We fix this by defining an explicit interface for these subroutines.